### PR TITLE
Update README.md and workflow

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   # This job runs tests and builds the project
   test-and-build:
+    # Skip this job if the PR is labeled as documentation-only
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'documentation') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -60,6 +62,8 @@ jobs:
 
   # This job builds the native binaries for multiple platforms
   build-native:
+    # Skip this job if the PR is labeled as documentation-only
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'documentation') }}
     needs: test-and-build
     strategy:
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,8 @@ jobs:
   # This job handles versioning and tagging
   release:
     # The 'if' condition ensures this job only runs for merged pull requests from develop to main
-    if: github.event.pull_request.merged == true && github.event.pull_request.head.ref == 'develop'
+    # and excludes documentation-only PRs
+    if: ${{ github.event.pull_request.merged == true && github.event.pull_request.head.ref == 'develop' && !contains(github.event.pull_request.labels.*.name, 'documentation') }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -97,6 +98,8 @@ jobs:
 
   # This job builds the native binaries for multiple platforms
   build-native:
+    # Skip this job if the PR is labeled as documentation-only
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'documentation') }}
     needs: release
     strategy:
       matrix:
@@ -190,6 +193,8 @@ jobs:
 
   # This job creates the GitHub Release and uploads the binaries
   create-release:
+    # Skip this job if the PR is labeled as documentation-only
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'documentation') }}
     needs: [release, build-native]
     runs-on: ubuntu-latest
     permissions:

--- a/README.md
+++ b/README.md
@@ -10,59 +10,54 @@
 
 # Syntaxpresso Core
 
-A powerful Rust-based CLI backend for IDE plugins that provides advanced Java code generation and manipulation capabilities using tree-sitter parsing technology.
+A standalone Rust-based CLI backend for IDE plugins that provides advanced Java code generation and manipulation capabilities using Tree-Sitter.
 
 ## Overview
 
 Syntaxpresso Core is designed as a backend service for IDE plugins, offering comprehensive Java code generation and manipulation through a CLI interface. The tool specializes in JPA (Java Persistence API) entity management, providing developers with automated code generation for complex Java persistence scenarios.
 
-## Features
+## Architecture
 
-### 🚀 Core Capabilities
-- **Tree-sitter powered parsing**: Leverages tree-sitter-java for accurate Java code analysis and manipulation
-- **JSON-based API**: All commands return structured JSON responses for easy IDE plugin integration
-- **JPA-focused**: Specialized tooling for Java Persistence API entities and relationships
-- **Cross-platform**: Native binaries available for Linux, macOS (Intel & ARM), and Windows
+The project is structured for maintainability and extensibility:
+
+```
+src/
+├── commands/           # CLI command implementations
+│   ├── services/       # Business logic services
+│   └── validators/     # Input validation
+├── common/
+│   ├── services/       # Shared services (annotations, imports, etc.)
+│   ├── types/          # Type definitions and configurations
+│   └── utils/          # Utility functions
+└── responses/          # Response type definitions
+```
+
+## Features
 
 ### 📋 Available Commands
 
 #### Entity Management
+
 - **`get-all-jpa-entities`**: Discover all JPA entities in a project
 - **`get-all-jpa-mapped-superclasses`**: Find all JPA mapped superclasses
 - **`create-jpa-entity`**: Generate new JPA entity classes
 - **`get-jpa-entity-info`**: Extract detailed information from existing entities
 
 #### Field Generation
+
 - **`create-jpa-entity-basic-field`**: Add basic fields with JPA annotations
 - **`create-jpa-entity-id-field`**: Create ID fields with generation strategies
 - **`create-jpa-entity-enum-field`**: Add enum fields with proper JPA mapping
 
 #### Relationship Management
+
 - **`create-jpa-one-to-one-relationship`**: Establish one-to-one entity relationships
 - **`create-jpa-many-to-one-relationship`**: Create many-to-one relationships with cascade options
 
 #### Repository & File Operations
+
 - **`create-jpa-repository`**: Generate Spring Data JPA repository interfaces
 - **`create-java-file`**: Create basic Java files (classes, interfaces, enums)
-
-## Installation
-
-### Pre-built Binaries
-
-Download the latest release for your platform:
-
-- **Linux**: `syntaxpresso-core-linux-amd64`
-- **macOS Intel**: `syntaxpresso-core-macos-amd64`
-- **macOS ARM**: `syntaxpresso-core-macos-arm64`
-- **Windows**: `syntaxpresso-core-windows-amd64.exe`
-
-### From Source
-
-```bash
-git clone https://github.com/syntaxpresso/core-rs.git
-cd core-rs
-cargo build --release
-```
 
 ## Usage
 
@@ -115,66 +110,23 @@ Error responses follow this format:
 }
 ```
 
-## IDE Plugin Integration
-
-Syntaxpresso Core is designed to be consumed by IDE plugins. The CLI interface provides:
-
-- **Consistent JSON output**: Easy to parse and integrate
-- **Comprehensive validation**: Input validation with clear error messages
-- **File path handling**: Robust path resolution and validation
-- **Base64 encoding support**: For passing source code directly
-
-## Architecture
-
-The project is structured for maintainability and extensibility:
-
-```
-src/
-├── commands/           # CLI command implementations
-│   ├── services/       # Business logic services
-│   └── validators/     # Input validation
-├── common/
-│   ├── services/       # Shared services (annotations, imports, etc.)
-│   ├── types/          # Type definitions and configurations
-│   └── utils/          # Utility functions
-└── responses/          # Response type definitions
-```
-
-## Configuration Options
-
-### Field Types
-- Support for all Java primitive and wrapper types
-- Custom type support with package resolution
-- Temporal field handling (`@Temporal` annotations)
-- Large object support (`@Lob` annotations)
-
-### JPA Features
-- **ID Generation**: AUTO, IDENTITY, SEQUENCE, TABLE strategies
-- **Cascade Types**: ALL, PERSIST, MERGE, REMOVE, REFRESH, DETACH
-- **Fetch Types**: EAGER, LAZY
-- **Collection Types**: List, Set, Map support
-- **Mapping Types**: JoinColumn, JoinTable customization
-
 ## Development
 
 ### Prerequisites
+
 - Rust 2024 Edition
 - Cargo package manager
 
 ### Building
+
 ```bash
 cargo build
 ```
 
 ### Testing
+
 ```bash
 cargo test
-```
-
-### Code Quality
-```bash
-cargo fmt
-cargo clippy
 ```
 
 ## Contributing
@@ -186,10 +138,6 @@ cargo clippy
 5. Run quality checks
 6. Submit a pull request
 
-## License
-
-[Add your license information here]
-
 ## Support
 
-For issues, questions, or contributions, please visit the [GitHub repository](https://github.com/syntaxpresso/core-rs).
+For issues, questions, or contributions, please visit the [GitHub repository](https://github.com/syntaxpresso/core).

--- a/README.md
+++ b/README.md
@@ -113,6 +113,15 @@ src/
 ```
 
 ### How it communicates with your IDE
+
+Communication follows a **unidirectional request-response model** handled via standard input/output (stdio). The syntaxpresso-core is a stateless CLI application that only prints a single JSON response to stdout before exiting; it never sends commands back to the IDE.
+
+- Request (IDE to Core): The IDE plugin spawns the compiled syntaxpresso-core binary as a new process for each request.
+- All required information (the command, file paths, options) is passed as CLI arguments at spawn time.
+- Execution (Core): The Rust application parses the arguments, executes the requested command, and performs all logic internally.
+- Response (Core to IDE): Upon completion, the Rust core serializes a standard Response object into a single JSON string and prints it to stdout.
+- Result (IDE): The IDE plugin captures this stdout, parses the JSON, and uses the structured data (e.g., file paths, success status, or error details) to update its state. The Rust process then terminates.
+
 <div align="center">
   <img width="500" alt="syntaxpresso-archtecture" src="https://github.com/user-attachments/assets/ddd3cd2d-3f03-4bbf-b855-8fc17248b3c2" />
 </div>

--- a/README.md
+++ b/README.md
@@ -16,22 +16,6 @@ A standalone Rust-based CLI backend for IDE plugins that provides advanced Java 
 
 Syntaxpresso Core is designed as a backend service for IDE plugins, offering comprehensive Java code generation and manipulation through a CLI interface. The tool specializes in JPA (Java Persistence API) entity management, providing developers with automated code generation for complex Java persistence scenarios.
 
-## Architecture
-
-The project is structured for maintainability and extensibility:
-
-```
-src/
-├── commands/           # CLI command implementations
-│   ├── services/       # Business logic services
-│   └── validators/     # Input validation
-├── common/
-│   ├── services/       # Shared services (annotations, imports, etc.)
-│   ├── types/          # Type definitions and configurations
-│   └── utils/          # Utility functions
-└── responses/          # Response type definitions
-```
-
 ## Features
 
 ### 📋 Available Commands
@@ -111,6 +95,27 @@ Error responses follow this format:
 ```
 
 ## Development
+
+### Architecture
+
+The project is structured for maintainability and extensibility:
+
+```
+src/
+├── commands/           # CLI command implementations
+│   ├── services/       # Business logic services
+│   └── validators/     # Input validation
+├── common/
+│   ├── services/       # Shared services (annotations, imports, etc.)
+│   ├── types/          # Type definitions and configurations
+│   └── utils/          # Utility functions
+└── responses/          # Response type definitions
+```
+
+### How it communicates with your IDE
+<div align="center">
+  <img width="500" alt="syntaxpresso-archtecture" src="https://github.com/user-attachments/assets/ddd3cd2d-3f03-4bbf-b855-8fc17248b3c2" />
+</div>
 
 ### Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+<div align="center">
+  <img width="500" alt="syntaxpresso" src="https://github.com/user-attachments/assets/be0749b2-1e53-469c-8d99-012024622ade" />
+</div>
+
+<div align="center">
+  <img alt="rust" src="https://img.shields.io/badge/built%20with-Rust-orange?logo=rust" />
+  <img alt="GitHub branch check runs" src="https://img.shields.io/github/check-runs/syntaxpresso/core/develop">
+  <img alt="GitHub Downloads (all assets, latest release)" src="https://img.shields.io/github/downloads/syntaxpresso/core/latest/total">
+</div>

--- a/README.md
+++ b/README.md
@@ -7,3 +7,189 @@
   <img alt="GitHub branch check runs" src="https://img.shields.io/github/check-runs/syntaxpresso/core/develop">
   <img alt="GitHub Downloads (all assets, latest release)" src="https://img.shields.io/github/downloads/syntaxpresso/core/latest/total">
 </div>
+
+# Syntaxpresso Core
+
+A powerful Rust-based CLI backend for IDE plugins that provides advanced Java code generation and manipulation capabilities using tree-sitter parsing technology.
+
+## Overview
+
+Syntaxpresso Core is designed as a backend service for IDE plugins, offering comprehensive Java code generation and manipulation through a CLI interface. The tool specializes in JPA (Java Persistence API) entity management, providing developers with automated code generation for complex Java persistence scenarios.
+
+## Features
+
+### 🚀 Core Capabilities
+- **Tree-sitter powered parsing**: Leverages tree-sitter-java for accurate Java code analysis and manipulation
+- **JSON-based API**: All commands return structured JSON responses for easy IDE plugin integration
+- **JPA-focused**: Specialized tooling for Java Persistence API entities and relationships
+- **Cross-platform**: Native binaries available for Linux, macOS (Intel & ARM), and Windows
+
+### 📋 Available Commands
+
+#### Entity Management
+- **`get-all-jpa-entities`**: Discover all JPA entities in a project
+- **`get-all-jpa-mapped-superclasses`**: Find all JPA mapped superclasses
+- **`create-jpa-entity`**: Generate new JPA entity classes
+- **`get-jpa-entity-info`**: Extract detailed information from existing entities
+
+#### Field Generation
+- **`create-jpa-entity-basic-field`**: Add basic fields with JPA annotations
+- **`create-jpa-entity-id-field`**: Create ID fields with generation strategies
+- **`create-jpa-entity-enum-field`**: Add enum fields with proper JPA mapping
+
+#### Relationship Management
+- **`create-jpa-one-to-one-relationship`**: Establish one-to-one entity relationships
+- **`create-jpa-many-to-one-relationship`**: Create many-to-one relationships with cascade options
+
+#### Repository & File Operations
+- **`create-jpa-repository`**: Generate Spring Data JPA repository interfaces
+- **`create-java-file`**: Create basic Java files (classes, interfaces, enums)
+
+## Installation
+
+### Pre-built Binaries
+
+Download the latest release for your platform:
+
+- **Linux**: `syntaxpresso-core-linux-amd64`
+- **macOS Intel**: `syntaxpresso-core-macos-amd64`
+- **macOS ARM**: `syntaxpresso-core-macos-arm64`
+- **Windows**: `syntaxpresso-core-windows-amd64.exe`
+
+### From Source
+
+```bash
+git clone https://github.com/syntaxpresso/core-rs.git
+cd core-rs
+cargo build --release
+```
+
+## Usage
+
+All commands follow a consistent pattern and return JSON responses:
+
+```bash
+# Basic entity creation
+./syntaxpresso-core create-jpa-entity \
+  --cwd /path/to/project \
+  --package-name com.example.entities \
+  --file-name User
+
+# Add a basic field to an entity
+./syntaxpresso-core create-jpa-entity-basic-field \
+  --cwd /path/to/project \
+  --entity-file-path /path/to/User.java \
+  --field-name username \
+  --field-type String \
+  --field-unique \
+  --field-nullable false
+
+# Create a one-to-one relationship
+./syntaxpresso-core create-jpa-one-to-one-relationship \
+  --cwd /path/to/project \
+  --owning-side-entity-file-path /path/to/User.java \
+  --owning-side-field-name profile \
+  --inverse-side-field-name user \
+  --inverse-field-type UserProfile
+```
+
+### Response Format
+
+All commands return structured JSON responses:
+
+```json
+{
+  "success": true,
+  "data": {
+    // Command-specific response data
+  }
+}
+```
+
+Error responses follow this format:
+
+```json
+{
+  "error": "execution_error",
+  "message": "Detailed error description"
+}
+```
+
+## IDE Plugin Integration
+
+Syntaxpresso Core is designed to be consumed by IDE plugins. The CLI interface provides:
+
+- **Consistent JSON output**: Easy to parse and integrate
+- **Comprehensive validation**: Input validation with clear error messages
+- **File path handling**: Robust path resolution and validation
+- **Base64 encoding support**: For passing source code directly
+
+## Architecture
+
+The project is structured for maintainability and extensibility:
+
+```
+src/
+├── commands/           # CLI command implementations
+│   ├── services/       # Business logic services
+│   └── validators/     # Input validation
+├── common/
+│   ├── services/       # Shared services (annotations, imports, etc.)
+│   ├── types/          # Type definitions and configurations
+│   └── utils/          # Utility functions
+└── responses/          # Response type definitions
+```
+
+## Configuration Options
+
+### Field Types
+- Support for all Java primitive and wrapper types
+- Custom type support with package resolution
+- Temporal field handling (`@Temporal` annotations)
+- Large object support (`@Lob` annotations)
+
+### JPA Features
+- **ID Generation**: AUTO, IDENTITY, SEQUENCE, TABLE strategies
+- **Cascade Types**: ALL, PERSIST, MERGE, REMOVE, REFRESH, DETACH
+- **Fetch Types**: EAGER, LAZY
+- **Collection Types**: List, Set, Map support
+- **Mapping Types**: JoinColumn, JoinTable customization
+
+## Development
+
+### Prerequisites
+- Rust 2024 Edition
+- Cargo package manager
+
+### Building
+```bash
+cargo build
+```
+
+### Testing
+```bash
+cargo test
+```
+
+### Code Quality
+```bash
+cargo fmt
+cargo clippy
+```
+
+## Contributing
+
+1. Fork the repository
+2. Create a feature branch
+3. Make your changes
+4. Add tests
+5. Run quality checks
+6. Submit a pull request
+
+## License
+
+[Add your license information here]
+
+## Support
+
+For issues, questions, or contributions, please visit the [GitHub repository](https://github.com/syntaxpresso/core-rs).


### PR DESCRIPTION
This pull request introduces improvements to both the CI/CD workflow and project documentation. The most significant changes are the addition of a comprehensive `README.md` and enhancements to the GitHub Actions workflows to skip unnecessary jobs for documentation-only pull requests.

Documentation:

* Added a detailed `README.md` with project overview, features, usage instructions, architecture diagram, and development guidelines.

CI/CD workflow optimizations:

* Updated `.github/workflows/develop.yml` to skip the `test-and-build` and `build-native` jobs when a PR is labeled as documentation-only. [[1]](diffhunk://#diff-dc1f0538462ec99cd0ba70c1de6c897f03e83c141cd0f3b22659d527a294d9fbR14-R15) [[2]](diffhunk://#diff-dc1f0538462ec99cd0ba70c1de6c897f03e83c141cd0f3b22659d527a294d9fbR65-R66)
* Updated `.github/workflows/release.yml` to ensure the `release`, `build-native`, and `create-release` jobs do not run for documentation-only PRs. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L14-R15) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R101-R102) [[3]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R196-R197)