### PR TITLE
Make sure all paths passed as command argument belongs to cwd path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,6 +68,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bitflags"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+
+[[package]]
 name = "cc"
 version = "1.2.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -76,6 +82,12 @@ dependencies = [
  "find-msvc-tools",
  "shlex",
 ]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clap"
@@ -132,6 +144,7 @@ dependencies = [
  "heck",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror",
  "tree-sitter",
  "tree-sitter-java",
@@ -145,10 +158,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52051878f80a721bb68ebfbc930e07b65ba72f2da88968ea5c06fd6ca3d3a127"
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+]
 
 [[package]]
 name = "hashbrown"
@@ -185,10 +226,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "libc"
+version = "0.2.177"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+
+[[package]]
 name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+
+[[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -213,6 +272,12 @@ checksum = "ce25767e7b499d1b604768e7cde645d14cc8584231ea6b295e9c9eb22c02e1d1"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "regex"
@@ -242,6 +307,19 @@ name = "regex-syntax"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+
+[[package]]
+name = "rustix"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
 
 [[package]]
 name = "ryu"
@@ -332,6 +410,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -401,6 +492,15 @@ checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+dependencies = [
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -491,3 +591,9 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,6 @@ tree-sitter-java = "0.23.5"
 thiserror = "2.0.17"
 heck = "0.5.0"
 base64 = "0.22.1"
+
+[dev-dependencies]
+tempfile = "3.8"

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Syntaxpresso Core is designed as a backend service for IDE plugins, offering com
 
 ## Features
 
-### 📋 Available Commands
+### Available Commands
 
 #### Entity Management
 

--- a/src/commands/create_jpa_entity_basic_field_command.rs
+++ b/src/commands/create_jpa_entity_basic_field_command.rs
@@ -1,7 +1,10 @@
 use std::path::Path;
 
 use crate::{
-  commands::services::create_jpa_entity_basic_field_service::run,
+  commands::{
+    services::create_jpa_entity_basic_field_service::run,
+    validators::directory_validator::validate_file_path_within_base,
+  },
   common::types::basic_field_config::BasicFieldConfig,
   responses::{file_response::FileResponse, response::Response},
 };
@@ -13,6 +16,16 @@ pub fn execute(
 ) -> Response<FileResponse> {
   let cwd_string = cwd.display().to_string();
   let cmd_name = String::from("create-jpa-entity-basic-field");
+  // Security validation: ensure entity file path is within the cwd
+  let file_path_str = entity_file_path.display().to_string();
+  if let Err(error_msg) = validate_file_path_within_base(&file_path_str, cwd) {
+    return Response::error(
+      cmd_name,
+      cwd_string,
+      format!("Entity file path security validation failed: {}", error_msg),
+    );
+  }
+
   match run(cwd, entity_file_path, field_config) {
     Ok(response) => Response::success(cmd_name, cwd_string, response),
     Err(error_msg) => Response::error(cmd_name, cwd_string, error_msg),

--- a/src/commands/create_jpa_entity_enum_field_command.rs
+++ b/src/commands/create_jpa_entity_enum_field_command.rs
@@ -1,7 +1,10 @@
 use std::path::Path;
 
 use crate::{
-  commands::services::create_jpa_entity_enum_field_service::run,
+  commands::{
+    services::create_jpa_entity_enum_field_service::run,
+    validators::directory_validator::validate_file_path_within_base,
+  },
   common::types::enum_field_config::EnumFieldConfig,
   responses::{file_response::FileResponse, response::Response},
 };
@@ -13,6 +16,16 @@ pub fn execute(
 ) -> Response<FileResponse> {
   let cwd_string = cwd.display().to_string();
   let cmd_name = String::from("create-jpa-entity-enum-field");
+  // Security validation: ensure entity file path is within the cwd
+  let file_path_str = entity_file_path.display().to_string();
+  if let Err(error_msg) = validate_file_path_within_base(&file_path_str, cwd) {
+    return Response::error(
+      cmd_name,
+      cwd_string,
+      format!("Entity file path security validation failed: {}", error_msg),
+    );
+  }
+
   match run(cwd, entity_file_path, field_config) {
     Ok(response) => Response::success(cmd_name, cwd_string, response),
     Err(error_msg) => Response::error(cmd_name, cwd_string, error_msg),

--- a/src/commands/create_jpa_entity_id_field_command.rs
+++ b/src/commands/create_jpa_entity_id_field_command.rs
@@ -1,7 +1,10 @@
 use std::path::Path;
 
 use crate::{
-  commands::services::create_jpa_entity_id_field_service::run,
+  commands::{
+    services::create_jpa_entity_id_field_service::run,
+    validators::directory_validator::validate_file_path_within_base,
+  },
   common::types::id_field_config::IdFieldConfig,
   responses::{file_response::FileResponse, response::Response},
 };
@@ -13,6 +16,16 @@ pub fn execute(
 ) -> Response<FileResponse> {
   let cwd_string = cwd.display().to_string();
   let cmd_name = String::from("create-jpa-entity-id-field");
+  // Security validation: ensure entity file path is within the cwd
+  let file_path_str = entity_file_path.display().to_string();
+  if let Err(error_msg) = validate_file_path_within_base(&file_path_str, cwd) {
+    return Response::error(
+      cmd_name,
+      cwd_string,
+      format!("Entity file path security validation failed: {}", error_msg),
+    );
+  }
+
   match run(cwd, entity_file_path, field_config) {
     Ok(response) => Response::success(cmd_name, cwd_string, response),
     Err(error_msg) => Response::error(cmd_name, cwd_string, error_msg),

--- a/src/commands/create_jpa_many_to_one_relationship_command.rs
+++ b/src/commands/create_jpa_many_to_one_relationship_command.rs
@@ -1,7 +1,10 @@
 use std::path::Path;
 
 use crate::{
-  commands::services::create_jpa_many_to_one_relationship_service,
+  commands::{
+    services::create_jpa_many_to_one_relationship_service,
+    validators::directory_validator::validate_file_path_within_base,
+  },
   common::types::many_to_one_field_config::ManyToOneFieldConfig,
   responses::{get_files_response::GetFilesResponse, response::Response},
 };
@@ -15,6 +18,16 @@ pub fn execute(
 ) -> Response<GetFilesResponse> {
   let cwd_string = cwd.display().to_string();
   let cmd_name = String::from("create-jpa-many-to-one-relationship");
+  // Security validation: ensure owning side entity file path is within the cwd
+  let file_path_str = owning_side_entity_file_path.display().to_string();
+  if let Err(error_msg) = validate_file_path_within_base(&file_path_str, cwd) {
+    return Response::error(
+      cmd_name,
+      cwd_string,
+      format!("Owning side entity file path security validation failed: {}", error_msg),
+    );
+  }
+
   match create_jpa_many_to_one_relationship_service::run(
     cwd,
     owning_side_entity_file_path,

--- a/src/commands/create_jpa_one_to_one_relationship_command.rs
+++ b/src/commands/create_jpa_one_to_one_relationship_command.rs
@@ -1,7 +1,10 @@
 use std::path::Path;
 
 use crate::{
-  commands::services::create_jpa_one_to_one_relationship_service,
+  commands::{
+    services::create_jpa_one_to_one_relationship_service,
+    validators::directory_validator::validate_file_path_within_base,
+  },
   common::types::one_to_one_field_config::OneToOneFieldConfig,
   responses::{get_files_response::GetFilesResponse, response::Response},
 };
@@ -15,6 +18,16 @@ pub fn execute(
 ) -> Response<GetFilesResponse> {
   let cwd_string = cwd.display().to_string();
   let cmd_name = String::from("create-jpa-one-to-one-relationship");
+  // Security validation: ensure owning side entity file path is within the cwd
+  let file_path_str = owning_side_entity_file_path.display().to_string();
+  if let Err(error_msg) = validate_file_path_within_base(&file_path_str, cwd) {
+    return Response::error(
+      cmd_name,
+      cwd_string,
+      format!("Owning side entity file path security validation failed: {}", error_msg),
+    );
+  }
+
   match create_jpa_one_to_one_relationship_service::run(
     cwd,
     owning_side_entity_file_path,

--- a/src/commands/create_jpa_repository_command.rs
+++ b/src/commands/create_jpa_repository_command.rs
@@ -1,7 +1,10 @@
 use std::path::Path;
 
 use crate::{
-  commands::services::create_jpa_repository_service::run,
+  commands::{
+    services::create_jpa_repository_service::run,
+    validators::directory_validator::validate_file_path_within_base,
+  },
   responses::{create_jpa_repository_response::CreateJPARepositoryResponse, response::Response},
 };
 
@@ -12,6 +15,16 @@ pub fn execute(
 ) -> Response<CreateJPARepositoryResponse> {
   let cwd_string = cwd.display().to_string();
   let cmd_name = String::from("create-jpa-repository");
+  // Security validation: ensure entity file path is within the cwd
+  let file_path_str = file_path.display().to_string();
+  if let Err(error_msg) = validate_file_path_within_base(&file_path_str, cwd) {
+    return Response::error(
+      cmd_name,
+      cwd_string,
+      format!("Entity file path security validation failed: {}", error_msg),
+    );
+  }
+
   match run(cwd, file_path, b64_superclass_source) {
     Ok(response) => Response::success(cmd_name, cwd_string, response),
     Err(error_msg) => Response::error(cmd_name, cwd_string, error_msg),

--- a/src/commands/get_jpa_entity_info_command.rs
+++ b/src/commands/get_jpa_entity_info_command.rs
@@ -1,7 +1,10 @@
 use std::path::Path;
 
 use crate::{
-  commands::services::get_jpa_entity_info_service::run,
+  commands::{
+    services::get_jpa_entity_info_service::run,
+    validators::directory_validator::validate_file_path_within_base,
+  },
   responses::{get_jpa_entity_info_response::GetJpaEntityInfoResponse, response::Response},
 };
 
@@ -12,6 +15,18 @@ pub fn execute(
 ) -> Response<GetJpaEntityInfoResponse> {
   let cwd_string = cwd.display().to_string();
   let cmd_name = String::from("get-jpa-entity-info");
+  // Security validation: ensure entity file path (if provided) is within the cwd
+  if let Some(file_path) = entity_file_path {
+    let file_path_str = file_path.display().to_string();
+    if let Err(error_msg) = validate_file_path_within_base(&file_path_str, cwd) {
+      return Response::error(
+        cmd_name,
+        cwd_string,
+        format!("Entity file path security validation failed: {}", error_msg),
+      );
+    }
+  }
+
   match run(entity_file_path, b64_source_code) {
     Ok(response) => Response::success(cmd_name, cwd_string, response),
     Err(error_msg) => Response::error(cmd_name, cwd_string, error_msg),

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -18,7 +18,8 @@ use clap::Subcommand;
 
 use crate::{
   commands::validators::{
-    directory_validator::validate_directory_unrestricted, java_class_name_validator::validate_java_class_name,
+    directory_validator::validate_directory_unrestricted,
+    java_class_name_validator::validate_java_class_name,
     package_name_validator::validate_package_name,
   },
   common::types::{

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -18,7 +18,7 @@ use clap::Subcommand;
 
 use crate::{
   commands::validators::{
-    directory_validator::validate_directory, java_class_name_validator::validate_java_class_name,
+    directory_validator::validate_directory_secure, java_class_name_validator::validate_java_class_name,
     package_name_validator::validate_package_name,
   },
   common::types::{
@@ -37,15 +37,15 @@ use crate::{
 #[derive(Subcommand)]
 pub enum Commands {
   GetAllJPAEntities {
-    #[arg(long, value_parser = validate_directory, required = true)]
+    #[arg(long, value_parser = validate_directory_secure, required = true)]
     cwd: PathBuf,
   },
   GetAllJPAMappedSuperclasses {
-    #[arg(long, value_parser = validate_directory, required = true)]
+    #[arg(long, value_parser = validate_directory_secure, required = true)]
     cwd: PathBuf,
   },
   CreateJavaFile {
-    #[arg(long, value_parser = validate_directory, required = true)]
+    #[arg(long, value_parser = validate_directory_secure, required = true)]
     cwd: PathBuf,
 
     #[arg(long, value_parser = validate_package_name, required = true)]
@@ -61,7 +61,7 @@ pub enum Commands {
     source_directory: JavaSourceDirectoryType,
   },
   CreateJPAEntity {
-    #[arg(long, value_parser = validate_directory, required = true)]
+    #[arg(long, value_parser = validate_directory_secure, required = true)]
     cwd: PathBuf,
 
     #[arg(long, value_parser = validate_package_name, required = true)]
@@ -71,7 +71,7 @@ pub enum Commands {
     file_name: String,
   },
   CreateJPARepository {
-    #[arg(long, value_parser = validate_directory, required = true)]
+    #[arg(long, value_parser = validate_directory_secure, required = true)]
     cwd: PathBuf,
 
     #[arg(long, required = true)]
@@ -81,7 +81,7 @@ pub enum Commands {
     b64_superclass_source: Option<String>,
   },
   GetJPAEntityInfo {
-    #[arg(long, value_parser = validate_directory, required = true)]
+    #[arg(long, value_parser = validate_directory_secure, required = true)]
     cwd: PathBuf,
 
     #[arg(long, required = false)]
@@ -91,7 +91,7 @@ pub enum Commands {
     b64_source_code: Option<String>,
   },
   CreateJPAEntityBasicField {
-    #[arg(long, value_parser = validate_directory, required = true)]
+    #[arg(long, value_parser = validate_directory_secure, required = true)]
     cwd: PathBuf,
 
     #[arg(long, required = true)]
@@ -131,7 +131,7 @@ pub enum Commands {
     field_large_object: bool,
   },
   CreateJPAEntityIdField {
-    #[arg(long, value_parser = validate_directory, required = true)]
+    #[arg(long, value_parser = validate_directory_secure, required = true)]
     cwd: PathBuf,
 
     #[arg(long, required = true)]
@@ -168,7 +168,7 @@ pub enum Commands {
     field_nullable: bool,
   },
   CreateJPAEntityEnumField {
-    #[arg(long, value_parser = validate_directory, required = true)]
+    #[arg(long, value_parser = validate_directory_secure, required = true)]
     cwd: PathBuf,
 
     #[arg(long, required = true)]
@@ -196,7 +196,7 @@ pub enum Commands {
     field_unique: bool,
   },
   CreateJPAOneToOneRelationship {
-    #[arg(long, value_parser = validate_directory, required = true)]
+    #[arg(long, value_parser = validate_directory_secure, required = true)]
     cwd: PathBuf,
 
     #[arg(long, required = true)]
@@ -227,7 +227,7 @@ pub enum Commands {
     inverse_side_other: Vec<OtherType>,
   },
   CreateJPAManyToOneRelationship {
-    #[arg(long, value_parser = validate_directory, required = true)]
+    #[arg(long, value_parser = validate_directory_secure, required = true)]
     cwd: PathBuf,
 
     #[arg(long, required = true)]

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -18,7 +18,7 @@ use clap::Subcommand;
 
 use crate::{
   commands::validators::{
-    directory_validator::validate_directory_secure, java_class_name_validator::validate_java_class_name,
+    directory_validator::validate_directory_unrestricted, java_class_name_validator::validate_java_class_name,
     package_name_validator::validate_package_name,
   },
   common::types::{
@@ -37,15 +37,15 @@ use crate::{
 #[derive(Subcommand)]
 pub enum Commands {
   GetAllJPAEntities {
-    #[arg(long, value_parser = validate_directory_secure, required = true)]
+    #[arg(long, value_parser = validate_directory_unrestricted, required = true)]
     cwd: PathBuf,
   },
   GetAllJPAMappedSuperclasses {
-    #[arg(long, value_parser = validate_directory_secure, required = true)]
+    #[arg(long, value_parser = validate_directory_unrestricted, required = true)]
     cwd: PathBuf,
   },
   CreateJavaFile {
-    #[arg(long, value_parser = validate_directory_secure, required = true)]
+    #[arg(long, value_parser = validate_directory_unrestricted, required = true)]
     cwd: PathBuf,
 
     #[arg(long, value_parser = validate_package_name, required = true)]
@@ -61,7 +61,7 @@ pub enum Commands {
     source_directory: JavaSourceDirectoryType,
   },
   CreateJPAEntity {
-    #[arg(long, value_parser = validate_directory_secure, required = true)]
+    #[arg(long, value_parser = validate_directory_unrestricted, required = true)]
     cwd: PathBuf,
 
     #[arg(long, value_parser = validate_package_name, required = true)]
@@ -71,7 +71,7 @@ pub enum Commands {
     file_name: String,
   },
   CreateJPARepository {
-    #[arg(long, value_parser = validate_directory_secure, required = true)]
+    #[arg(long, value_parser = validate_directory_unrestricted, required = true)]
     cwd: PathBuf,
 
     #[arg(long, required = true)]
@@ -81,7 +81,7 @@ pub enum Commands {
     b64_superclass_source: Option<String>,
   },
   GetJPAEntityInfo {
-    #[arg(long, value_parser = validate_directory_secure, required = true)]
+    #[arg(long, value_parser = validate_directory_unrestricted, required = true)]
     cwd: PathBuf,
 
     #[arg(long, required = false)]
@@ -91,7 +91,7 @@ pub enum Commands {
     b64_source_code: Option<String>,
   },
   CreateJPAEntityBasicField {
-    #[arg(long, value_parser = validate_directory_secure, required = true)]
+    #[arg(long, value_parser = validate_directory_unrestricted, required = true)]
     cwd: PathBuf,
 
     #[arg(long, required = true)]
@@ -131,7 +131,7 @@ pub enum Commands {
     field_large_object: bool,
   },
   CreateJPAEntityIdField {
-    #[arg(long, value_parser = validate_directory_secure, required = true)]
+    #[arg(long, value_parser = validate_directory_unrestricted, required = true)]
     cwd: PathBuf,
 
     #[arg(long, required = true)]
@@ -168,7 +168,7 @@ pub enum Commands {
     field_nullable: bool,
   },
   CreateJPAEntityEnumField {
-    #[arg(long, value_parser = validate_directory_secure, required = true)]
+    #[arg(long, value_parser = validate_directory_unrestricted, required = true)]
     cwd: PathBuf,
 
     #[arg(long, required = true)]
@@ -196,7 +196,7 @@ pub enum Commands {
     field_unique: bool,
   },
   CreateJPAOneToOneRelationship {
-    #[arg(long, value_parser = validate_directory_secure, required = true)]
+    #[arg(long, value_parser = validate_directory_unrestricted, required = true)]
     cwd: PathBuf,
 
     #[arg(long, required = true)]
@@ -227,7 +227,7 @@ pub enum Commands {
     inverse_side_other: Vec<OtherType>,
   },
   CreateJPAManyToOneRelationship {
-    #[arg(long, value_parser = validate_directory_secure, required = true)]
+    #[arg(long, value_parser = validate_directory_unrestricted, required = true)]
     cwd: PathBuf,
 
     #[arg(long, required = true)]

--- a/src/commands/services/create_jpa_entity_service.rs
+++ b/src/commands/services/create_jpa_entity_service.rs
@@ -103,9 +103,9 @@ fn add_table_name_argument(ts_file: &mut TSFile, class_name: &str) -> Result<(),
   }
 }
 
-fn save_ts_file(ts_file: &mut TSFile, file_path: &str) -> Result<(), String> {
+fn save_ts_file(ts_file: &mut TSFile, file_path: &str, base_path: &Path) -> Result<(), String> {
   let save_path = std::path::Path::new(file_path);
-  ts_file.save_as(save_path).map_err(|_| "Failed to save file".to_string())
+  ts_file.save_as(save_path, base_path).map_err(|e| format!("Failed to save file: {}", e))
 }
 
 pub fn run(cwd: &Path, package_name: &str, file_name: &str) -> Result<FileResponse, String> {
@@ -128,7 +128,7 @@ pub fn run(cwd: &Path, package_name: &str, file_name: &str) -> Result<FileRespon
   // Step 8: Add table name argument with snake_case conversion
   add_table_name_argument(&mut ts_file, &normalized_class_name)?;
   // Step 9: Save the updated TSFile to disk
-  save_ts_file(&mut ts_file, &file_response.file_path)?;
+  save_ts_file(&mut ts_file, &file_response.file_path, cwd)?;
   // Step 10: Build and return the final file response
   build_file_response(&ts_file, package_name)
 }

--- a/src/commands/validators/directory_validator.rs
+++ b/src/commands/validators/directory_validator.rs
@@ -62,17 +62,13 @@ pub fn validate_file_path_within_base(
 /// ```
 pub fn validate_directory_unrestricted(s: &str) -> Result<PathBuf, String> {
   let path = PathBuf::from(s);
-  
   // Basic validation - ensure directory exists and is accessible
   if !path.exists() {
     return Err(format!("Directory does not exist: {}", s));
   }
-  
   if !path.is_dir() {
     return Err(format!("Path is not a directory: {}", s));
   }
-  
   // Canonicalize to resolve any symbolic links and get absolute path
-  path.canonicalize()
-    .map_err(|e| format!("Cannot canonicalize directory path '{}': {}", s, e))
+  path.canonicalize().map_err(|e| format!("Cannot canonicalize directory path '{}': {}", s, e))
 }

--- a/src/commands/validators/directory_validator.rs
+++ b/src/commands/validators/directory_validator.rs
@@ -1,58 +1,6 @@
 use crate::common::utils::path_security_util::PathSecurityValidator;
 use std::path::PathBuf;
 
-/// Validates a directory with additional security checks to ensure it's within allowed scope.
-/// This function prevents path traversal attacks by validating the directory against the current working directory.
-///
-/// # Arguments
-/// * `s` - The directory path string to validate
-/// * `base_path` - Optional base path to validate against. If None, uses current working directory
-///
-/// # Returns
-/// * `Ok(PathBuf)` - The canonicalized, validated directory path
-/// * `Err(String)` - If the directory is invalid, doesn't exist, or is outside the allowed scope
-///
-/// # Security Features
-/// - Prevents path traversal attacks (e.g., "../../../etc")
-/// - Resolves symbolic links to prevent symlink attacks
-/// - Ensures directory stays within the specified base path
-///
-/// # Examples
-/// ```
-/// use std::path::Path;
-/// use crate::commands::validators::directory_validator::validate_directory_with_security;
-///
-/// // Validate against current working directory
-/// let safe_dir = validate_directory_with_security("src/main/java", None)?;
-///
-/// // Validate against specific base path
-/// let base = Path::new("/project/root");
-/// let safe_dir = validate_directory_with_security("src/main/java", Some(base))?;
-/// ```
-pub fn validate_directory_with_security(
-  s: &str,
-  base_path: Option<&std::path::Path>,
-) -> Result<PathBuf, String> {
-  let path = PathBuf::from(s);
-  // Basic validation first
-  if !path.exists() || !path.is_dir() {
-    return Err(format!("Directory does not exist or is not a directory: {}", s));
-  }
-  // Determine base path for security validation
-  let base = match base_path {
-    Some(bp) => bp.to_path_buf(),
-    None => {
-      std::env::current_dir().map_err(|e| format!("Cannot determine current directory: {}", e))?
-    }
-  };
-  // Security validation - ensure the directory is within allowed scope
-  let validator = PathSecurityValidator::new(&base)
-    .map_err(|e| format!("Security validation setup failed: {}", e))?;
-  validator
-    .validate_path_containment(&path)
-    .map_err(|e| format!("Security validation failed: {}", e))
-}
-
 /// Validates a file path with security checks to ensure it's within the specified base directory.
 /// This function prevents path traversal attacks and ensures files can only be accessed within allowed scope.
 ///
@@ -127,33 +75,4 @@ pub fn validate_directory_unrestricted(s: &str) -> Result<PathBuf, String> {
   // Canonicalize to resolve any symbolic links and get absolute path
   path.canonicalize()
     .map_err(|e| format!("Cannot canonicalize directory path '{}': {}", s, e))
-}
-
-/// Wrapper function for validate_directory_with_security that uses current directory as base.
-/// This function is designed for use with clap's value_parser to provide secure directory validation
-/// for command line arguments, preventing path traversal attacks on working directory parameters.
-///
-/// # Arguments
-/// * `s` - The directory path string to validate
-///
-/// # Returns
-/// * `Ok(PathBuf)` - The canonicalized, validated directory path
-/// * `Err(String)` - If the directory is invalid, doesn't exist, or attempts path traversal
-///
-/// # Security Features
-/// - Uses current working directory as security base to prevent escaping user context
-/// - Prevents path traversal attacks (e.g., "../../../etc")
-/// - Resolves symbolic links to prevent symlink attacks
-/// - Ensures directory stays within allowed scope
-///
-/// # Usage with clap
-/// ```rust
-/// #[arg(long, value_parser = validate_directory_secure, required = true)]
-/// cwd: PathBuf,
-/// ```
-pub fn validate_directory_secure(s: &str) -> Result<PathBuf, String> {
-  // Use current directory as security base to prevent escaping user's context
-  let current_dir =
-    std::env::current_dir().map_err(|e| format!("Cannot determine current directory: {}", e))?;
-  validate_directory_with_security(s, Some(&current_dir))
 }

--- a/src/commands/validators/directory_validator.rs
+++ b/src/commands/validators/directory_validator.rs
@@ -1,10 +1,121 @@
+use crate::common::utils::path_security_util::PathSecurityValidator;
 use std::path::PathBuf;
 
-pub fn validate_directory(s: &str) -> Result<PathBuf, String> {
+/// Validates a directory with additional security checks to ensure it's within allowed scope.
+/// This function prevents path traversal attacks by validating the directory against the current working directory.
+///
+/// # Arguments
+/// * `s` - The directory path string to validate
+/// * `base_path` - Optional base path to validate against. If None, uses current working directory
+///
+/// # Returns
+/// * `Ok(PathBuf)` - The canonicalized, validated directory path
+/// * `Err(String)` - If the directory is invalid, doesn't exist, or is outside the allowed scope
+///
+/// # Security Features
+/// - Prevents path traversal attacks (e.g., "../../../etc")
+/// - Resolves symbolic links to prevent symlink attacks
+/// - Ensures directory stays within the specified base path
+///
+/// # Examples
+/// ```
+/// use std::path::Path;
+/// use crate::commands::validators::directory_validator::validate_directory_with_security;
+///
+/// // Validate against current working directory
+/// let safe_dir = validate_directory_with_security("src/main/java", None)?;
+///
+/// // Validate against specific base path
+/// let base = Path::new("/project/root");
+/// let safe_dir = validate_directory_with_security("src/main/java", Some(base))?;
+/// ```
+pub fn validate_directory_with_security(
+  s: &str,
+  base_path: Option<&std::path::Path>,
+) -> Result<PathBuf, String> {
   let path = PathBuf::from(s);
-  if path.exists() && path.is_dir() {
-    Ok(path)
-  } else {
-    Err(format!("Directory does not exist: {}", s))
+  // Basic validation first
+  if !path.exists() || !path.is_dir() {
+    return Err(format!("Directory does not exist or is not a directory: {}", s));
   }
+  // Determine base path for security validation
+  let base = match base_path {
+    Some(bp) => bp.to_path_buf(),
+    None => {
+      std::env::current_dir().map_err(|e| format!("Cannot determine current directory: {}", e))?
+    }
+  };
+  // Security validation - ensure the directory is within allowed scope
+  let validator = PathSecurityValidator::new(&base)
+    .map_err(|e| format!("Security validation setup failed: {}", e))?;
+  validator
+    .validate_path_containment(&path)
+    .map_err(|e| format!("Security validation failed: {}", e))
+}
+
+/// Validates a file path with security checks to ensure it's within the specified base directory.
+/// This function prevents path traversal attacks and ensures files can only be accessed within allowed scope.
+///
+/// # Arguments
+/// * `file_path` - The file path string to validate
+/// * `base_path` - The base directory that the file must be contained within
+///
+/// # Returns
+/// * `Ok(PathBuf)` - The canonicalized, validated file path
+/// * `Err(String)` - If the file path is invalid or outside the allowed scope
+///
+/// # Security Features
+/// - Prevents path traversal attacks (e.g., "../../../etc/passwd")
+/// - Resolves symbolic links to prevent symlink attacks
+/// - Ensures file path stays within the specified base directory
+/// - Handles both existing and non-existent files
+///
+/// # Examples
+/// ```
+/// use std::path::Path;
+/// use crate::commands::validators::directory_validator::validate_file_path_within_base;
+///
+/// let base = Path::new("/project/src");
+/// let safe_file = validate_file_path_within_base("entities/User.java", base)?;
+/// ```
+pub fn validate_file_path_within_base(
+  file_path: &str,
+  base_path: &std::path::Path,
+) -> Result<PathBuf, String> {
+  let path = PathBuf::from(file_path);
+  // Security validation - ensure the file path is within allowed scope
+  let validator = PathSecurityValidator::new(base_path)
+    .map_err(|e| format!("Security validation setup failed: {}", e))?;
+  validator
+    .validate_path_containment(&path)
+    .map_err(|e| format!("File path security validation failed: {}", e))
+}
+
+/// Wrapper function for validate_directory_with_security that uses current directory as base.
+/// This function is designed for use with clap's value_parser to provide secure directory validation
+/// for command line arguments, preventing path traversal attacks on working directory parameters.
+///
+/// # Arguments
+/// * `s` - The directory path string to validate
+///
+/// # Returns
+/// * `Ok(PathBuf)` - The canonicalized, validated directory path
+/// * `Err(String)` - If the directory is invalid, doesn't exist, or attempts path traversal
+///
+/// # Security Features
+/// - Uses current working directory as security base to prevent escaping user context
+/// - Prevents path traversal attacks (e.g., "../../../etc")
+/// - Resolves symbolic links to prevent symlink attacks
+/// - Ensures directory stays within allowed scope
+///
+/// # Usage with clap
+/// ```rust
+/// #[arg(long, value_parser = validate_directory_secure, required = true)]
+/// cwd: PathBuf,
+/// ```
+pub fn validate_directory_secure(s: &str) -> Result<PathBuf, String> {
+  // Use current directory as security base to prevent escaping user's context
+  let current_dir =
+    std::env::current_dir().map_err(|e| format!("Cannot determine current directory: {}", e))?;
+  validate_directory_with_security(s, Some(&current_dir))
 }

--- a/src/common/utils/mod.rs
+++ b/src/common/utils/mod.rs
@@ -1,2 +1,3 @@
 pub mod case_util;
+pub mod path_security_util;
 pub mod path_util;

--- a/src/common/utils/path_security_util.rs
+++ b/src/common/utils/path_security_util.rs
@@ -1,0 +1,218 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// A security validator that ensures all file operations stay within a designated base directory.
+/// This prevents path traversal attacks and ensures files can only be created/modified within
+/// the allowed directory scope.
+pub struct PathSecurityValidator {
+  base_path: PathBuf,
+}
+
+/// Security event types for audit logging
+#[derive(Debug)]
+pub enum SecurityEvent {
+  PathValidationSuccess { target_path: String, base_path: String },
+  PathValidationFailure { target_path: String, base_path: String, reason: String },
+  PathTraversalAttempt { target_path: String, base_path: String },
+  SymlinkDetected { target_path: String, resolved_path: String },
+}
+
+/// Log a security event to stderr for audit purposes
+/// This provides a simple audit trail without requiring external logging dependencies
+fn log_security_event(event: &SecurityEvent) {
+  let timestamp = std::time::SystemTime::now()
+    .duration_since(std::time::UNIX_EPOCH)
+    .unwrap_or_else(|_| std::time::Duration::from_secs(0))
+    .as_secs();
+
+  match event {
+    SecurityEvent::PathValidationSuccess { target_path, base_path } => {
+      eprintln!(
+        "[SECURITY] [{}] Path validation SUCCESS: '{}' within base '{}'",
+        timestamp, target_path, base_path
+      );
+    }
+    SecurityEvent::PathValidationFailure { target_path, base_path, reason } => {
+      eprintln!(
+        "[SECURITY] [{}] Path validation FAILURE: '{}' within base '{}' - {}",
+        timestamp, target_path, base_path, reason
+      );
+    }
+    SecurityEvent::PathTraversalAttempt { target_path, base_path } => {
+      eprintln!(
+        "[SECURITY] [{}] PATH TRAVERSAL ATTEMPT BLOCKED: '{}' outside base '{}'",
+        timestamp, target_path, base_path
+      );
+    }
+    SecurityEvent::SymlinkDetected { target_path, resolved_path } => {
+      eprintln!(
+        "[SECURITY] [{}] Symlink detected and resolved: '{}' -> '{}'",
+        timestamp, target_path, resolved_path
+      );
+    }
+  }
+}
+
+impl PathSecurityValidator {
+  /// Creates a new path security validator with the given base path.
+  /// The base path is canonicalized to resolve any symbolic links or relative components.
+  ///
+  /// # Arguments
+  /// * `base_path` - The base directory that all operations must be contained within
+  ///
+  /// # Returns
+  /// * `Ok(PathSecurityValidator)` - If the base path is valid and accessible
+  /// * `Err(String)` - If the base path cannot be canonicalized or accessed
+  ///
+  /// # Examples
+  /// ```
+  /// use std::path::Path;
+  /// use crate::common::utils::path_security_util::PathSecurityValidator;
+  ///
+  /// let validator = PathSecurityValidator::new(Path::new("/project/root"))?;
+  /// ```
+  pub fn new(base_path: &Path) -> Result<Self, String> {
+    let canonical_base = fs::canonicalize(base_path)
+      .map_err(|e| format!("Cannot canonicalize base path '{}': {}", base_path.display(), e))?;
+
+    if !canonical_base.is_dir() {
+      return Err(format!("Base path '{}' is not a directory", canonical_base.display()));
+    }
+
+    Ok(Self { base_path: canonical_base })
+  }
+
+  /// Validates that a target path is contained within the base path.
+  /// This method prevents path traversal attacks by ensuring the resolved path
+  /// is within the allowed directory scope.
+  ///
+  /// # Arguments
+  /// * `target_path` - The path to validate for containment
+  ///
+  /// # Returns
+  /// * `Ok(PathBuf)` - The canonicalized path if it's within the base directory
+  /// * `Err(String)` - If the path is outside the base directory or invalid
+  ///
+  /// # Security Features
+  /// - Resolves symbolic links to prevent symlink attacks
+  /// - Handles both existing and non-existing paths
+  /// - Prevents directory traversal with `../` sequences
+  /// - Blocks absolute paths that escape the base directory
+  ///
+  /// # Examples
+  /// ```
+  /// let validator = PathSecurityValidator::new(Path::new("/project"))?;
+  /// let safe_path = validator.validate_path_containment(Path::new("src/main.rs"))?;
+  /// ```
+  pub fn validate_path_containment(&self, target_path: &Path) -> Result<PathBuf, String> {
+    // Handle absolute paths - convert to relative if they're within base
+    let working_path = if target_path.is_absolute() {
+      if target_path.starts_with(&self.base_path) {
+        target_path
+          .strip_prefix(&self.base_path)
+          .map_err(|_| "Failed to strip base path prefix".to_string())?
+          .to_path_buf()
+      } else {
+        return Err(format!(
+          "Absolute path '{}' is outside allowed directory '{}'",
+          target_path.display(),
+          self.base_path.display()
+        ));
+      }
+    } else {
+      target_path.to_path_buf()
+    };
+
+    // Build the full path relative to base
+    let full_path = self.base_path.join(&working_path);
+
+    // Canonicalize the target path
+    let canonical_target = if full_path.exists() {
+      // Path exists - canonicalize directly
+      fs::canonicalize(&full_path).map_err(|e| {
+        format!("Cannot canonicalize existing path '{}': {}", full_path.display(), e)
+      })?
+    } else {
+      // Path doesn't exist yet - canonicalize parent and append filename
+      canonicalize_non_existent_path(&full_path)?
+    };
+
+    // Verify containment after canonicalization
+    if !canonical_target.starts_with(&self.base_path) {
+      let event = SecurityEvent::PathTraversalAttempt {
+        target_path: target_path.display().to_string(),
+        base_path: self.base_path.display().to_string(),
+      };
+      log_security_event(&event);
+
+      return Err(format!(
+        "Path traversal detected: '{}' resolves to '{}' which is outside allowed directory '{}'",
+        target_path.display(),
+        canonical_target.display(),
+        self.base_path.display()
+      ));
+    }
+
+    // Log successful validation
+    let event = SecurityEvent::PathValidationSuccess {
+      target_path: target_path.display().to_string(),
+      base_path: self.base_path.display().to_string(),
+    };
+    log_security_event(&event);
+
+    Ok(canonical_target)
+  }
+
+  /// Validates that a path intended for directory creation is safe.
+  /// This is a specialized version of path validation for directory operations.
+  pub fn validate_directory_creation(&self, target_path: &Path) -> Result<PathBuf, String> {
+    let validated_path = self.validate_path_containment(target_path)?;
+    // Additional check: if the path exists, ensure it's a directory
+    if validated_path.exists() && !validated_path.is_dir() {
+      return Err(format!("Path '{}' exists but is not a directory", validated_path.display()));
+    }
+    Ok(validated_path)
+  }
+  /// Returns the base path used for validation
+  pub fn base_path(&self) -> &Path {
+    &self.base_path
+  }
+}
+
+/// Handle canonicalization for non-existent paths by canonicalizing the parent
+/// and appending the filename/directory name
+fn canonicalize_non_existent_path(path: &Path) -> Result<PathBuf, String> {
+  if let Some(parent) = path.parent() {
+    let canonical_parent = if parent.exists() {
+      fs::canonicalize(parent).map_err(|e| {
+        format!("Cannot canonicalize parent directory '{}': {}", parent.display(), e)
+      })?
+    } else {
+      // Recursively handle non-existent parents
+      canonicalize_non_existent_path(parent)?
+    };
+
+    if let Some(filename) = path.file_name() {
+      Ok(canonical_parent.join(filename))
+    } else {
+      Err(format!("Invalid path structure: '{}'", path.display()))
+    }
+  } else {
+    Err(format!("Cannot determine parent directory for path: '{}'", path.display()))
+  }
+}
+
+/// Convenience function to create a validator and validate a path in one step
+pub fn validate_path_within_base(base_path: &Path, target_path: &Path) -> Result<PathBuf, String> {
+  let validator = PathSecurityValidator::new(base_path)?;
+  validator.validate_path_containment(target_path)
+}
+
+/// Convenience function to validate directory creation within a base path
+pub fn validate_directory_creation_within_base(
+  base_path: &Path,
+  target_path: &Path,
+) -> Result<PathBuf, String> {
+  let validator = PathSecurityValidator::new(base_path)?;
+  validator.validate_directory_creation(target_path)
+}

--- a/src/common/utils/path_util.rs
+++ b/src/common/utils/path_util.rs
@@ -5,7 +5,10 @@ use std::path::{Path, PathBuf};
 
 use walkdir::WalkDir;
 
-use crate::common::{ts_file::TSFile, types::java_source_directory_type::JavaSourceDirectoryType};
+use crate::common::{
+  ts_file::TSFile, types::java_source_directory_type::JavaSourceDirectoryType,
+  utils::path_security_util::PathSecurityValidator,
+};
 
 /// Recursively searches for a directory with the given name within the root directory.
 ///
@@ -49,13 +52,21 @@ pub fn parse_all_files(cwd: &Path, source_directory_type: &JavaSourceDirectoryTy
 /// This function finds the appropriate source directory (main or test), converts the package
 /// scope (e.g., "com.example.foo") to a directory path, and ensures the directory exists.
 ///
+/// **Security**: This function now includes path traversal protection to ensure all created
+/// directories remain within the root directory scope.
+///
 /// # Arguments
 /// * `root_dir` - The root directory of the project
 /// * `package_scope` - The package scope as a dot-separated string (e.g., "com.example.foo")
 /// * `source_directory_type` - The type of source directory (main or test)
 ///
 /// # Returns
-/// An `Option<PathBuf>` containing the resolved package directory path, or `None` if not found or on error
+/// A `Result<PathBuf, String>` containing the resolved package directory path, or an error message
+///
+/// # Security Features
+/// - Validates that the resolved path stays within the root directory
+/// - Prevents path traversal attacks through package names
+/// - Ensures directory creation is safe and contained
 ///
 /// # Examples
 /// ```
@@ -67,29 +78,44 @@ pub fn parse_all_files(cwd: &Path, source_directory_type: &JavaSourceDirectoryTy
 ///     project_root,
 ///     "com.example.foo",
 ///     &JavaSourceDirectoryType::Main
-/// );
-/// if let Some(dir) = package_dir {
-///     // Use dir as the directory for new source files
-/// }
+/// )?;
+/// // Use package_dir as the directory for new source files
 /// ```
 pub fn get_file_path_from_package_scope(
   root_dir: &Path,
   package_scope: &str,
   source_directory_type: &JavaSourceDirectoryType,
-) -> Option<PathBuf> {
+) -> Result<PathBuf, String> {
+  // Basic validation
   if !root_dir.exists() || !root_dir.is_dir() {
-    return None;
+    return Err(format!(
+      "Root directory does not exist or is not a directory: {}",
+      root_dir.display()
+    ));
   }
   if package_scope.trim().is_empty() {
-    return None;
+    return Err("Package scope cannot be empty".to_string());
   }
+  // Create security validator for the root directory
+  let validator = PathSecurityValidator::new(root_dir)?;
+  // Find or construct the source directory
   let src_dir_name = source_directory_type.get_directory_path();
   let source_dir = find_directory_recursively(root_dir, src_dir_name)
     .unwrap_or_else(|| root_dir.join(src_dir_name));
+  // Validate that the source directory is within root (for the constructed case)
+  let validated_source_dir = validator.validate_directory_creation(&source_dir)?;
+  // Convert package scope to path (e.g., "com.example.foo" -> "com/example/foo")
   let package_as_path = package_scope.replace('.', "/");
-  let full_package_dir = source_dir.join(package_as_path);
-  match fs::create_dir_all(&full_package_dir) {
-    Ok(_) => Some(full_package_dir),
-    Err(_) => None,
+  let full_package_dir = validated_source_dir.join(package_as_path);
+  // Validate the full package directory path for security
+  let validated_package_dir = validator.validate_directory_creation(&full_package_dir)?;
+  // Create the directory structure
+  match fs::create_dir_all(&validated_package_dir) {
+    Ok(_) => Ok(validated_package_dir),
+    Err(e) => Err(format!(
+      "Failed to create package directory '{}': {}",
+      validated_package_dir.display(),
+      e
+    )),
   }
 }


### PR DESCRIPTION
This pull request introduces significant improvements to security and path validation across multiple commands in the codebase, ensuring that file operations are restricted to the intended working directory. It also refactors command argument validation to allow for unrestricted directory input where appropriate, and makes minor documentation and dependency updates. These changes collectively enhance the robustness and maintainability of the backend service.

### Security and Path Validation

* Added security validation to all commands that operate on files, using `validate_file_path_within_base` to ensure file paths are contained within the current working directory. This prevents potential directory traversal vulnerabilities. (`src/commands/create_jpa_entity_basic_field_command.rs`, `src/commands/create_jpa_entity_enum_field_command.rs`, `src/commands/create_jpa_entity_id_field_command.rs`, `src/commands/create_jpa_many_to_one_relationship_command.rs`, `src/commands/create_jpa_one_to_one_relationship_command.rs`, `src/commands/create_jpa_repository_command.rs`, `src/commands/get_jpa_entity_info_command.rs`) [[1]](diffhunk://#diff-2836c143da8ea69d279d342e1fd008d34022b38ad2086c8ef6a96ba34503c304L4-R7) [[2]](diffhunk://#diff-2836c143da8ea69d279d342e1fd008d34022b38ad2086c8ef6a96ba34503c304R19-R28) [[3]](diffhunk://#diff-40285c21a451df3cba211f1a06ae1d7d00fa4f965697c938bc2a1bf09cb845bbL4-R7) [[4]](diffhunk://#diff-40285c21a451df3cba211f1a06ae1d7d00fa4f965697c938bc2a1bf09cb845bbR19-R28) [[5]](diffhunk://#diff-ff6836fa3bcf229d64577481bb2084c86156ebf630a6996fb194287024a66315L4-R7) [[6]](diffhunk://#diff-ff6836fa3bcf229d64577481bb2084c86156ebf630a6996fb194287024a66315R19-R28) [[7]](diffhunk://#diff-7248072df2c96c15775069cd760babf126f5925db19f28aa81448087348de639L4-R7) [[8]](diffhunk://#diff-7248072df2c96c15775069cd760babf126f5925db19f28aa81448087348de639R21-R30) [[9]](diffhunk://#diff-c57900c85aef18853836b369ea77591d29339986b3052e2abbc1edbd8380ca91L4-R7) [[10]](diffhunk://#diff-c57900c85aef18853836b369ea77591d29339986b3052e2abbc1edbd8380ca91R21-R30) [[11]](diffhunk://#diff-066afd8004026cd7b8324d3f9411269a03395da7f9b9e72fbb62f1826932e1f5L4-R7) [[12]](diffhunk://#diff-066afd8004026cd7b8324d3f9411269a03395da7f9b9e72fbb62f1826932e1f5R18-R27) [[13]](diffhunk://#diff-b7ba10d2ad973078f92a126783eef9f56a8107e45506aee3e7f9bdc38088ede0L4-R7) [[14]](diffhunk://#diff-b7ba10d2ad973078f92a126783eef9f56a8107e45506aee3e7f9bdc38088ede0R18-R29)
* Refactored file save logic in services to use a new `PathSecurityValidator`, ensuring that files are only written within allowed directories. (`src/commands/services/create_java_file_service.rs`, `src/commands/services/create_jpa_entity_service.rs`) [[1]](diffhunk://#diff-c40cd84bded57853ca31e718eb0391f86515366333c390236e2964c0d43bb6fbR7) [[2]](diffhunk://#diff-c40cd84bded57853ca31e718eb0391f86515366333c390236e2964c0d43bb6fbL34-R51) [[3]](diffhunk://#diff-c40cd84bded57853ca31e718eb0391f86515366333c390236e2964c0d43bb6fbL66-R84) [[4]](diffhunk://#diff-ef5d4af2b6bd1b68c1b75234e04127f4c03b22d5c2338fa422a97bc6f1721c52L106-R108)

### Command Argument Validation

* Changed directory argument validation for all commands from `validate_directory` to `validate_directory_unrestricted`, allowing more flexible directory input while maintaining security through explicit path checks. (`src/commands/mod.rs`) [[1]](diffhunk://#diff-bf2f650cdc66abd13076c47b25e8c9f783f06ec335bbd30822fdd690547615fdL21-R22) [[2]](diffhunk://#diff-bf2f650cdc66abd13076c47b25e8c9f783f06ec335bbd30822fdd690547615fdL40-R49) [[3]](diffhunk://#diff-bf2f650cdc66abd13076c47b25e8c9f783f06ec335bbd30822fdd690547615fdL64-R65) [[4]](diffhunk://#diff-bf2f650cdc66abd13076c47b25e8c9f783f06ec335bbd30822fdd690547615fdL74-R75) [[5]](diffhunk://#diff-bf2f650cdc66abd13076c47b25e8c9f783f06ec335bbd30822fdd690547615fdL84-R85) [[6]](diffhunk://#diff-bf2f650cdc66abd13076c47b25e8c9f783f06ec335bbd30822fdd690547615fdL94-R95) [[7]](diffhunk://#diff-bf2f650cdc66abd13076c47b25e8c9f783f06ec335bbd30822fdd690547615fdL134-R135) [[8]](diffhunk://#diff-bf2f650cdc66abd13076c47b25e8c9f783f06ec335bbd30822fdd690547615fdL171-R172) [[9]](diffhunk://#diff-bf2f650cdc66abd13076c47b25e8c9f783f06ec335bbd30822fdd690547615fdL199-R200) [[10]](diffhunk://#diff-bf2f650cdc66abd13076c47b25e8c9f783f06ec335bbd30822fdd690547615fdL230-R231)

### Documentation

* Minor update to the README for clarity, removing an emoji and simplifying section headers. (`README.md`)

### Dependency Updates

* Added `tempfile` as a development dependency in `Cargo.toml` for improved testing capabilities. (`Cargo.toml`)