### PR TITLE
Ensure parent directories are created before saving file

### DIFF
--- a/src/common/ts_file.rs
+++ b/src/common/ts_file.rs
@@ -236,6 +236,10 @@ impl TSFile {
       .validate_path_containment(path)
       .map_err(|e| std::io::Error::other(format!("Path security validation failed: {}", e)))?;
     // Save using the validated path
+    // Create parent directories if they don't exist
+    if let Some(parent) = validated_path.parent() {
+      fs::create_dir_all(parent)?;
+    }
     fs::write(&validated_path, &self.source_code)?;
     self.file = Some(validated_path);
     self.modified = false;


### PR DESCRIPTION
This pull request introduces a small but important improvement to the file-saving logic in the `TSFile` implementation. Before writing the file, it now ensures that any necessary parent directories are created if they don't already exist.

* Automatically creates parent directories for the validated file path before saving, preventing potential errors when the directory structure does not exist. (`src/common/ts_file.rs`)