### PR TITLE
Ensure parent directories are created before saving file

### DIFF
--- a/src/common/ts_file.rs
+++ b/src/common/ts_file.rs
@@ -236,6 +236,10 @@ impl TSFile {
       .validate_path_containment(path)
       .map_err(|e| std::io::Error::other(format!("Path security validation failed: {}", e)))?;
     // Save using the validated path
+    // Create parent directories if they don't exist
+    if let Some(parent) = validated_path.parent() {
+      fs::create_dir_all(parent)?;
+    }
     fs::write(&validated_path, &self.source_code)?;
     self.file = Some(validated_path);
     self.modified = false;


### PR DESCRIPTION
This pull request adds a small but important improvement to the file saving logic in the `TSFile` implementation. Now, when saving a file, the code ensures that any necessary parent directories are created if they do not already exist.

File saving robustness:

* Before writing the file, the code checks for the existence of parent directories and creates them as needed using `fs::create_dir_all`, preventing errors when saving to nested paths. (`src/common/ts_file.rs`, [src/common/ts_file.rsR239-R242](diffhunk://#diff-f11a914782c332bb900d57b89366eed71e02bd363d8a185e275bde8b6fd4e20cR239-R242))