### PR TITLE
fix(ci): ensure release workflow bumps and pushes Cargo.toml version …

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.base.ref }}
+          ref: main
 
       - name: Set up Rust
         uses: actions-rs/toolchain@v1
@@ -86,9 +86,11 @@ jobs:
           echo "New version: $NEW_VERSION"
 
           # Update Cargo.toml version
-          sed -i "s/^version = .*/version = \"$NEW_VERSION\"/" Cargo.toml
-          git add Cargo.toml
-          git commit -m "chore: bump version to $NEW_VERSION" || echo "No changes to commit"
+           sed -i "s/^version = .*/version = \"$NEW_VERSION\"/" Cargo.toml
+           git add Cargo.toml
+           git commit -m "chore: bump version to $NEW_VERSION"
+           git push origin main
+
 
           # Set output and create tag
           echo "VERSION=$NEW_VERSION" >> $GITHUB_OUTPUT


### PR DESCRIPTION
This pull request updates the release workflow in `.github/workflows/release.yml` to ensure that releases are always based on the latest `main` branch and that version bumps are reliably pushed to the remote repository. The main changes focus on improving the consistency and automation of the release process.

**Release workflow improvements:**

* Changed the branch reference in the checkout step to always use `main`, ensuring releases are built from the latest code on the default branch.
* Updated the version bump step to always commit changes and added a step to push the updated `main` branch to the remote repository after bumping the version, ensuring that version changes are reflected in the remote repository.…and tag correctly