### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.base.ref }}
+          ref: main
 
       - name: Set up Rust
         uses: actions-rs/toolchain@v1
@@ -86,9 +86,11 @@ jobs:
           echo "New version: $NEW_VERSION"
 
           # Update Cargo.toml version
-          sed -i "s/^version = .*/version = \"$NEW_VERSION\"/" Cargo.toml
-          git add Cargo.toml
-          git commit -m "chore: bump version to $NEW_VERSION" || echo "No changes to commit"
+           sed -i "s/^version = .*/version = \"$NEW_VERSION\"/" Cargo.toml
+           git add Cargo.toml
+           git commit -m "chore: bump version to $NEW_VERSION"
+           git push origin main
+
 
           # Set output and create tag
           echo "VERSION=$NEW_VERSION" >> $GITHUB_OUTPUT


### PR DESCRIPTION
This pull request updates the release workflow configuration in `.github/workflows/release.yml` to ensure that version bumps and related commits are pushed directly to the `main` branch, streamlining the release process.

Workflow configuration updates:

* Changed the checkout step to always use the `main` branch instead of the pull request base reference, ensuring consistency during releases.

Release automation improvements:

* Added a step to push version bump commits directly to the `main` branch after updating `Cargo.toml`, automating the release workflow and reducing manual intervention.