### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     # Outputs that can be used by other jobs
     outputs:
       version: ${{ steps.create_version.outputs.VERSION }}
@@ -85,161 +86,30 @@ jobs:
           NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}"
           echo "New version: $NEW_VERSION"
 
-          # Update Cargo.toml version
+           # Update Cargo.toml version
            sed -i "s/^version = .*/version = \"$NEW_VERSION\"/" Cargo.toml
+           
+           # Create and push release branch
+           BRANCH_NAME="release/v${NEW_VERSION}"
+           git checkout -b "$BRANCH_NAME"
            git add Cargo.toml
            git commit -m "chore: bump version to $NEW_VERSION"
-           git push origin main
+           git push origin "$BRANCH_NAME"
+
+           # Create PR for version bump
+           gh pr create \
+             --title "Release: v${NEW_VERSION}" \
+             --body "Automated version bump to v${NEW_VERSION} for release" \
+             --base main \
+             --head "$BRANCH_NAME" \
+             --label "release"
+         env:
+           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+       - name: Set outputs
+         run: |
+           # Set output (tag creation will happen in separate workflow after PR merge)
+           echo "VERSION=$NEW_VERSION" >> $GITHUB_OUTPUT
+           echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_OUTPUT
 
 
-          # Set output and create tag
-          echo "VERSION=$NEW_VERSION" >> $GITHUB_OUTPUT
-          echo "Creating tag: v${NEW_VERSION}"
-          git tag "v${NEW_VERSION}"
-          git push origin "v${NEW_VERSION}"
-
-  # This job builds the native binaries for multiple platforms
-  build-native:
-    # Skip this job if the PR is labeled as documentation-only
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'documentation') }}
-    needs: release
-    strategy:
-      matrix:
-        include:
-          - os: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
-            platform: linux
-            arch: amd64
-            binary_name: syntaxpresso-core
-            output_name: syntaxpresso-core-linux-amd64
-          - os: macos-13
-            target: x86_64-apple-darwin
-            platform: macos
-            arch: amd64
-            binary_name: syntaxpresso-core
-            output_name: syntaxpresso-core-macos-amd64
-          - os: macos-latest
-            target: aarch64-apple-darwin
-            platform: macos
-            arch: arm64
-            binary_name: syntaxpresso-core
-            output_name: syntaxpresso-core-macos-arm64
-          - os: windows-latest
-            target: x86_64-pc-windows-msvc
-            platform: windows
-            arch: amd64
-            binary_name: syntaxpresso-core.exe
-            output_name: syntaxpresso-core-windows-amd64.exe
-    runs-on: ${{ matrix.os }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Set up Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          target: ${{ matrix.target }}
-          profile: minimal
-          override: true
-
-      - name: Install cross-compilation dependencies (Linux)
-        if: matrix.os == 'ubuntu-latest'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y gcc-multilib
-
-      - name: Build release binary
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --release --target ${{ matrix.target }}
-
-      - name: Rename binary for platform
-        run: |
-          if [ -f "target/${{ matrix.target }}/release/${{ matrix.binary_name }}" ]; then
-            cp "target/${{ matrix.target }}/release/${{ matrix.binary_name }}" "${{ matrix.output_name }}"
-            echo "Copied ${{ matrix.binary_name }} to ${{ matrix.output_name }}"
-          else
-            echo "Binary ${{ matrix.binary_name }} not found!"
-            ls -la target/${{ matrix.target }}/release/
-            exit 1
-          fi
-        shell: bash
-
-      - name: Make binary executable (Unix)
-        if: matrix.platform != 'windows'
-        run: |
-          chmod +x "${{ matrix.output_name }}"
-          echo "Made ${{ matrix.output_name }} executable"
-
-      - name: Verify renamed binary
-        run: |
-          if [ -f "${{ matrix.output_name }}" ]; then
-            echo "Successfully created ${{ matrix.output_name }}"
-            ls -la "${{ matrix.output_name }}"
-          else
-            echo "Failed to create ${{ matrix.output_name }}"
-            exit 1
-          fi
-        shell: bash
-
-      - name: Upload binary as artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: binary-${{ matrix.platform }}-${{ matrix.arch }}
-          path: ${{ matrix.output_name }}
-          retention-days: 1
-
-  # This job creates the GitHub Release and uploads the binaries
-  create-release:
-    # Skip this job if the PR is labeled as documentation-only
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'documentation') }}
-    needs: [release, build-native]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Download all artifacts
-        uses: actions/download-artifact@v4
-        with:
-          path: binaries
-
-      - name: List downloaded files
-        run: |
-          echo "Contents of binaries directory:"
-          ls -la binaries/
-          echo ""
-          echo "Contents of each subdirectory:"
-          for dir in binaries/*/; do
-            echo "Contents of $dir:"
-            ls -la "$dir"
-          done
-
-      - name: Prepare release files
-        run: |
-          mkdir -p release-files
-          cp binaries/binary-linux-amd64/syntaxpresso-core-linux-amd64 release-files/ || true
-          cp binaries/binary-macos-amd64/syntaxpresso-core-macos-amd64 release-files/ || true
-          cp binaries/binary-macos-arm64/syntaxpresso-core-macos-arm64 release-files/ || true
-          cp binaries/binary-windows-amd64/syntaxpresso-core-windows-amd64.exe release-files/ || true
-          # Make Unix binaries executable
-          chmod +x release-files/syntaxpresso-core-linux-amd64 || true
-          chmod +x release-files/syntaxpresso-core-macos-amd64 || true
-          chmod +x release-files/syntaxpresso-core-macos-arm64 || true
-          echo "Final release files with permissions:"
-          ls -la release-files/
-
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: v${{ needs.release.outputs.version }}
-          generate_release_notes: true
-          files: release-files/*

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,0 +1,188 @@
+# Name for the workflow
+name: Tag Release
+
+# Controls when the workflow will run
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - "main"
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This job creates tags for merged release PRs
+  create-tag:
+    # Only run for merged PRs with the release label
+    if: ${{ github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'release') }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      version: ${{ steps.extract_version.outputs.VERSION }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: main
+
+      - name: Configure Git
+        run: |
+          git config user.name "GitHub Actions"
+          git config user.email "actions@github.com"
+
+      - name: Extract version from Cargo.toml
+        id: extract_version
+        run: |
+          VERSION=$(grep '^version = ' Cargo.toml | sed 's/version = "\(.*\)"/\1/')
+          echo "Extracted version: $VERSION"
+          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Create and push tag
+        run: |
+          VERSION="${{ steps.extract_version.outputs.VERSION }}"
+          echo "Creating tag: v${VERSION}"
+          git tag "v${VERSION}"
+          git push origin "v${VERSION}"
+
+  # This job builds the native binaries for multiple platforms
+  build-native:
+    needs: create-tag
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            platform: linux
+            arch: amd64
+            binary_name: syntaxpresso-core
+            output_name: syntaxpresso-core-linux-amd64
+          - os: macos-13
+            target: x86_64-apple-darwin
+            platform: macos
+            arch: amd64
+            binary_name: syntaxpresso-core
+            output_name: syntaxpresso-core-macos-amd64
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            platform: macos
+            arch: arm64
+            binary_name: syntaxpresso-core
+            output_name: syntaxpresso-core-macos-arm64
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            platform: windows
+            arch: amd64
+            binary_name: syntaxpresso-core.exe
+            output_name: syntaxpresso-core-windows-amd64.exe
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: ${{ matrix.target }}
+          profile: minimal
+          override: true
+
+      - name: Install cross-compilation dependencies (Linux)
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-multilib
+
+      - name: Build release binary
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release --target ${{ matrix.target }}
+
+      - name: Rename binary for platform
+        run: |
+          if [ -f "target/${{ matrix.target }}/release/${{ matrix.binary_name }}" ]; then
+            cp "target/${{ matrix.target }}/release/${{ matrix.binary_name }}" "${{ matrix.output_name }}"
+            echo "Copied ${{ matrix.binary_name }} to ${{ matrix.output_name }}"
+          else
+            echo "Binary ${{ matrix.binary_name }} not found!"
+            ls -la target/${{ matrix.target }}/release/
+            exit 1
+          fi
+        shell: bash
+
+      - name: Make binary executable (Unix)
+        if: matrix.platform != 'windows'
+        run: |
+          chmod +x "${{ matrix.output_name }}"
+          echo "Made ${{ matrix.output_name }} executable"
+
+      - name: Verify renamed binary
+        run: |
+          if [ -f "${{ matrix.output_name }}" ]; then
+            echo "Successfully created ${{ matrix.output_name }}"
+            ls -la "${{ matrix.output_name }}"
+          else
+            echo "Failed to create ${{ matrix.output_name }}"
+            exit 1
+          fi
+        shell: bash
+
+      - name: Upload binary as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: binary-${{ matrix.platform }}-${{ matrix.arch }}
+          path: ${{ matrix.output_name }}
+          retention-days: 1
+
+  # This job creates the GitHub Release and uploads the binaries
+  create-release:
+    needs: [create-tag, build-native]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: binaries
+
+      - name: List downloaded files
+        run: |
+          echo "Contents of binaries directory:"
+          ls -la binaries/
+          echo ""
+          echo "Contents of each subdirectory:"
+          for dir in binaries/*/; do
+            echo "Contents of $dir:"
+            ls -la "$dir"
+          done
+
+      - name: Prepare release files
+        run: |
+          mkdir -p release-files
+          cp binaries/binary-linux-amd64/syntaxpresso-core-linux-amd64 release-files/ || true
+          cp binaries/binary-macos-amd64/syntaxpresso-core-macos-amd64 release-files/ || true
+          cp binaries/binary-macos-arm64/syntaxpresso-core-macos-arm64 release-files/ || true
+          cp binaries/binary-windows-amd64/syntaxpresso-core-windows-amd64.exe release-files/ || true
+          # Make Unix binaries executable
+          chmod +x release-files/syntaxpresso-core-linux-amd64 || true
+          chmod +x release-files/syntaxpresso-core-macos-amd64 || true
+          chmod +x release-files/syntaxpresso-core-macos-arm64 || true
+          echo "Final release files with permissions:"
+          ls -la release-files/
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ needs.create-tag.outputs.version }}
+          generate_release_notes: true
+          files: release-files/*


### PR DESCRIPTION
This pull request refactors the release automation workflow by splitting the previous monolithic process into two separate GitHub Actions workflows: one for creating a release pull request and another for tagging, building, and publishing the release after the PR is merged. This improves reliability and aligns with best practices for automated releases. The most important changes are grouped below.

**Workflow refactoring and separation:**

* The release process in `.github/workflows/release.yml` is reworked to create a dedicated release branch, push changes, and open a release PR instead of directly tagging and publishing on the main branch.
* A new workflow `.github/workflows/tag-release.yml` is added to handle tagging, building binaries, and publishing the release after the release PR is merged into `main` and labeled appropriately.

**GitHub permissions and automation improvements:**

* The `pull-requests: write` permission is added to the workflow to allow automated creation of release PRs.
* The release workflow now uses the GitHub CLI (`gh pr create`) to automate opening a PR for the version bump, including labeling and branch management.

**Build and release steps migration:**

* All build matrix and artifact upload steps for native binaries, as well as the GitHub Release creation, are moved from the original workflow to the new tag-based workflow, ensuring that releases only occur after the PR is merged.