### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -220,6 +220,14 @@ jobs:
         id: create_branch
         run: |
           NEW_VERSION="${{ needs.release.outputs.version }}"
+
+          # Fail fast if the version is empty from a partial re-run
+          if [ -z "$NEW_VERSION" ]; then
+            echo "Error: NEW_VERSION is empty. This can happen if you re-run only this job."
+            echo "Please re-run the entire workflow from the beginning."
+            exit 1
+          fi
+
           BRANCH_NAME="chore/bump-version-v${NEW_VERSION}"
           echo "Creating branch: $BRANCH_NAME"
 
@@ -235,7 +243,8 @@ jobs:
             echo "BRANCH_CREATED=false" >> $GITHUB_OUTPUT
           else
             git commit -m "chore: bump version to $NEW_VERSION after release"
-            git push origin $BRANCH_NAME
+            # Use --force to overwrite the branch if it exists from a previous failed run
+            git push --force origin $BRANCH_NAME
             echo "BRANCH_CREATED=true" >> $GITHUB_OUTPUT
             echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_OUTPUT
           fi


### PR DESCRIPTION
This pull request introduces improvements to the release workflow in `.github/workflows/release.yml` to make it more robust against partial re-runs and failed branch pushes. The main changes focus on error handling and ensuring branch creation works reliably.

Release workflow robustness:

* Added a check to fail fast if the `NEW_VERSION` variable is empty, which can happen if only part of the workflow is re-run. The workflow now instructs users to restart the entire process in this case.
* Updated the branch push command to use `--force`, ensuring that the branch is overwritten if it already exists due to a previous failed run. This prevents errors when retrying the workflow.