### PR TITLE
Use PAT for CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: main
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.SYNTAXPRESSO_CI }}
           fetch-depth: 0 # Fetch all history to find the last tag correctly
       - name: Configure git
         run: |


### PR DESCRIPTION
This pull request makes a small update to the GitHub Actions workflow configuration. The change replaces the authentication token used for checking out the repository during the release workflow.

* The `token` parameter in the `actions/checkout@v4` step of `.github/workflows/release.yml` is now set to use `${{ secrets.SYNTAXPRESSO_CI }}` instead of the default `${{ secrets.GITHUB_TOKEN }}`.