### PR TITLE
Add superclass heritage to create jpa entity command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -395,7 +395,7 @@ dependencies = [
 
 [[package]]
 name = "syntaxpresso-core"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "base64",
  "clap",

--- a/src/commands/create_jpa_entity_command.rs
+++ b/src/commands/create_jpa_entity_command.rs
@@ -5,10 +5,16 @@ use crate::{
   responses::{file_response::FileResponse, response::Response},
 };
 
-pub fn execute(cwd: &Path, package_name: &str, file_name: &str) -> Response<FileResponse> {
+pub fn execute(
+  cwd: &Path,
+  package_name: &str,
+  file_name: &str,
+  superclass_type: Option<&str>,
+  superclass_package_name: Option<&str>,
+) -> Response<FileResponse> {
   let cwd_string = cwd.display().to_string();
   let cmd_name = String::from("create-jpa-entity");
-  match run(cwd, package_name, file_name) {
+  match run(cwd, package_name, file_name, superclass_type, superclass_package_name) {
     Ok(response) => Response::success(cmd_name, cwd_string, response),
     Err(error_msg) => Response::error(cmd_name, cwd_string, error_msg),
   }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -88,6 +88,12 @@ pub enum Commands {
 
     #[arg(long, value_parser = validate_java_class_name, required = true)]
     file_name: String,
+
+    #[arg(long, required = false)]
+    superclass_type: Option<String>,
+
+    #[arg(long, required = false)]
+    superclass_package_name: Option<String>,
   },
   CreateJPARepository {
     #[arg(long, value_parser = validate_directory_unrestricted, required = true)]
@@ -307,8 +313,20 @@ impl Commands {
         );
         response.to_json_pretty().map_err(|e| e.into())
       }
-      Commands::CreateJPAEntity { cwd, package_name, file_name } => {
-        let response = create_jpa_entity_command::execute(cwd.as_path(), package_name, file_name);
+      Commands::CreateJPAEntity {
+        cwd,
+        package_name,
+        file_name,
+        superclass_type,
+        superclass_package_name,
+      } => {
+        let response = create_jpa_entity_command::execute(
+          cwd.as_path(),
+          package_name,
+          file_name,
+          superclass_type.as_deref(),
+          superclass_package_name.as_deref(),
+        );
         response.to_json_pretty().map_err(|e| e.into())
       }
       Commands::CreateJPARepository { cwd, entity_file_path, b64_superclass_source } => {


### PR DESCRIPTION
This pull request adds support for specifying a superclass when creating a JPA entity, allowing generated entities to inherit from a custom parent class. The changes include updates to the command-line interface, command execution logic, and the service responsible for generating JPA entities, as well as minor workflow improvements.

### JPA Entity Superclass Support

* Added `superclass_type` and `superclass_package_name` options to the `CreateJPAEntity` command, allowing users to specify a parent class for generated entities (`src/commands/mod.rs`, `src/commands/create_jpa_entity_command.rs`). [[1]](diffhunk://#diff-bf2f650cdc66abd13076c47b25e8c9f783f06ec335bbd30822fdd690547615fdR91-R96) [[2]](diffhunk://#diff-f0069c8eb9e8df85a8a8d1a1dda56511d68ad50d36453bee38bc1681264f83b4L8-R17)
* Updated the command execution logic to pass superclass options to the entity creation service (`src/commands/mod.rs`, `src/commands/create_jpa_entity_command.rs`). [[1]](diffhunk://#diff-bf2f650cdc66abd13076c47b25e8c9f783f06ec335bbd30822fdd690547615fdL310-R329) [[2]](diffhunk://#diff-f0069c8eb9e8df85a8a8d1a1dda56511d68ad50d36453bee38bc1681264f83b4L8-R17)
* Enhanced the JPA entity creation service to insert the appropriate `extends` clause and import statement when superclass options are provided (`src/commands/services/create_jpa_entity_service.rs`). [[1]](diffhunk://#diff-ef5d4af2b6bd1b68c1b75234e04127f4c03b22d5c2338fa422a97bc6f1721c52R109-R144) [[2]](diffhunk://#diff-ef5d4af2b6bd1b68c1b75234e04127f4c03b22d5c2338fa422a97bc6f1721c52L130-R167)

### Workflow Improvements

* Removed unnecessary `components: fmt` argument from the Rust toolchain setup in the development workflow (`.github/workflows/develop.yml`).
* Updated the commit message for version bumps in the release workflow for clarity (`.github/workflows/release.yml`).