### PR TITLE
Automatically sync the `develop` branch with `main` after a new version is released

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,9 +82,40 @@ jobs:
           echo "tag_created=true" >> $GITHUB_OUTPUT
       - name: Push commit and tag
         run: git push origin main --follow-tags
-  build-binaries:
+  sync-develop:
+    name: Sync develop branch with main
+    runs-on: ubuntu-latest
     if: needs.update-version-and-create-tag.outputs.tag_created == 'true'
     needs: update-version-and-create-tag
+    steps:
+      - name: Checkout main branch
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          token: ${{ secrets.SYNTAXPRESSO_CI }}
+          fetch-depth: 0
+      - name: Configure git
+        run: |
+          git config --global user.name 'Syntaxpresso[bot]'
+          git config --global user.email 'bot@syntaxpresso.github.io'
+      - name: Merge main into develop
+        run: |
+          echo "Fetching latest changes..."
+          git fetch origin main develop
+          
+          echo "Checking out develop branch..."
+          git checkout develop
+          
+          echo "Merging main into develop..."
+          git merge origin/main --no-ff -m "chore: sync develop with main after version ${{ needs.update-version-and-create-tag.outputs.new_version }} release"
+          
+          echo "Pushing changes to develop..."
+          git push origin develop
+          
+          echo "✓ Successfully synced develop with main"
+  build-binaries:
+    if: needs.update-version-and-create-tag.outputs.tag_created == 'true'
+    needs: [update-version-and-create-tag, sync-develop]
     strategy:
       matrix:
         include:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,16 +102,12 @@ jobs:
         run: |
           echo "Fetching latest changes..."
           git fetch origin main develop
-          
           echo "Checking out develop branch..."
           git checkout develop
-          
           echo "Merging main into develop..."
           git merge origin/main --no-ff -m "chore: sync develop with main after version ${{ needs.update-version-and-create-tag.outputs.new_version }} release"
-          
           echo "Pushing changes to develop..."
           git push origin develop
-          
           echo "✓ Successfully synced develop with main"
   build-binaries:
     if: needs.update-version-and-create-tag.outputs.tag_created == 'true'


### PR DESCRIPTION
This pull request updates the release workflow to automatically sync the `develop` branch with `main` after a new version is released. The main change is the addition of a new job that merges `main` into `develop` and pushes the update, ensuring both branches stay aligned after each release.

Release workflow improvements:

* Added a new `sync-develop` job to `.github/workflows/release.yml` that checks out `main`, merges it into `develop`, and pushes the changes to keep the branches in sync after a release.
* Updated the `build-binaries` job to depend on both the version/tag creation and the new `sync-develop` job, ensuring binaries are built only after branches are synchronized.