### PR TITLE
Update macos-13 to macos-15-intel runner to avoid deprecation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,7 +121,7 @@ jobs:
             arch: amd64
             binary_name: syntaxpresso-core
             output_name: syntaxpresso-core-linux-amd64
-          - os: macos-13
+          - os: macos-15-intel
             target: x86_64-apple-darwin
             platform: macos
             arch: amd64


### PR DESCRIPTION
This pull request makes a small update to the release workflow configuration. The macOS build job is updated to use the newer `macos-15-intel` runner instead of `macos-13`.