### PR TITLE
Use a newer macOS version for building the `syntaxpresso-core` binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,7 +121,7 @@ jobs:
             arch: amd64
             binary_name: syntaxpresso-core
             output_name: syntaxpresso-core-linux-amd64
-          - os: macos-13
+          - os: macos-15-intel
             target: x86_64-apple-darwin
             platform: macos
             arch: amd64


### PR DESCRIPTION
This pull request updates the release workflow configuration to use a newer macOS version for building the `syntaxpresso-core` binary. The change ensures that the build process targets `macos-15-intel` instead of the older `macos-13`, which may improve compatibility and take advantage of the latest macOS features.

* Release workflow update:
  * In `.github/workflows/release.yml`, changed the build target from `macos-13` to `macos-15-intel` for the `syntaxpresso-core` binary.