### PR TITLE
Ensures that the `GITHUB_TOKEN` is available as an environment variable during the version update and tagging step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,8 @@ jobs:
           git config --global user.email 'bot@syntaxpresso.github.io'
       - name: Update version and create tag
         id: bump
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           CURRENT_VERSION=$(grep '^version' Cargo.toml | head -n 1 | sed 's/version = "\(.*\)"/\1/')
           echo "Current version from Cargo.toml: $CURRENT_VERSION"


### PR DESCRIPTION
This pull request makes a minor update to the GitHub Actions workflow for releases. The change ensures that the `GITHUB_TOKEN` is available as an environment variable during the version update and tagging step.

* Added the `GITHUB_TOKEN` environment variable to the "Update version and create tag" step in `.github/workflows/release.yml` to support authentication for Git operations.