### PR TITLE
Ensures that the `GITHUB_TOKEN` is available as an environment variable during the version update and tagging step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,8 @@ jobs:
           git config --global user.email 'bot@syntaxpresso.github.io'
       - name: Update version and create tag
         id: bump
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           CURRENT_VERSION=$(grep '^version' Cargo.toml | head -n 1 | sed 's/version = "\(.*\)"/\1/')
           echo "Current version from Cargo.toml: $CURRENT_VERSION"


### PR DESCRIPTION
This pull request makes a small change to the release workflow configuration. The change ensures that the `GITHUB_TOKEN` environment variable is available during the version bump and tag creation step, which is necessary for authentication in GitHub Actions.

* Added `GITHUB_TOKEN` to the environment variables for the "Update version and create tag" step in `.github/workflows/release.yml`.