### PR TITLE
Ensure that GitHub authentication is available for the necessary steps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,8 @@ jobs:
           git config --global user.email 'bot@syntaxpresso.github.io'
       - name: Update version and create tag
         id: bump
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           CURRENT_VERSION=$(grep '^version' Cargo.toml | head -n 1 | sed 's/version = "\(.*\)"/\1/')
           echo "Current version from Cargo.toml: $CURRENT_VERSION"


### PR DESCRIPTION
This pull request makes a small update to the release workflow by adding the `GITHUB_TOKEN` environment variable to the step that updates the version and creates a tag. This change helps ensure that GitHub authentication is available for this step.