### PR TITLE
Improve create-jpa-entity logic by adding a validation to the `add_superclass_heritage` function to ensure that both the superclass type and its package name must be provided together

### DIFF
--- a/src/commands/services/create_jpa_entity_service.rs
+++ b/src/commands/services/create_jpa_entity_service.rs
@@ -111,6 +111,9 @@ fn add_superclass_heritage(
   superclass_type_opt: Option<&str>,
   superclass_package_name_opt: Option<&str>,
 ) -> Result<(), String> {
+  if superclass_type_opt.is_some() != superclass_package_name_opt.is_some() {
+    return Err("Both superclass type and it's package name are necessary".to_string());
+  }
   if superclass_type_opt.is_some() && superclass_package_name_opt.is_some() {
     let superclass_type = superclass_type_opt.ok_or("Superclass type not provided".to_string())?;
     let superclass_package_name =


### PR DESCRIPTION
This pull request adds a validation to the `add_superclass_heritage` function to ensure that both the superclass type and its package name must be provided together. If only one is provided, the function now returns an error message.

Validation improvement:

* Added a check in `add_superclass_heritage` in `src/commands/services/create_jpa_entity_service.rs` to require both `superclass_type_opt` and `superclass_package_name_opt` to be present, returning an error if only one is provided.…eritance