### PR TITLE
Fix JPA Entity creation logic

### DIFF
--- a/src/commands/services/create_java_file_service.rs
+++ b/src/commands/services/create_java_file_service.rs
@@ -4,30 +4,39 @@ use crate::{
   common::{
     ts_file::TSFile,
     types::{java_file_type::JavaFileType, java_source_directory_type::JavaSourceDirectoryType},
-    utils::path_security_util::PathSecurityValidator,
+    utils::{case_util, path_security_util::PathSecurityValidator},
   },
   responses::file_response::FileResponse,
 };
 
-fn generate_file_template(file_type: &JavaFileType, package_name: &str, file_name: &str) -> String {
+pub fn generate_file_template(
+  file_type: &JavaFileType,
+  package_name: &str,
+  file_name: &str,
+) -> String {
   file_type.get_source_content(package_name, file_name)
 }
 
-fn create_ts_file(file_template: &str) -> TSFile {
+pub fn create_ts_file(file_template: &str) -> TSFile {
   TSFile::from_source_code(file_template)
 }
 
-fn correct_java_file_name(file_name: &str) -> String {
+pub fn correct_java_file_name(file_name: &str) -> String {
   match std::path::Path::new(file_name).extension() {
     Some(ext) if ext == "java" => file_name.to_string(),
     _ => match std::path::Path::new(file_name).file_stem() {
-      Some(stem) => format!("{}.java", stem.to_string_lossy()),
+      Some(stem) => {
+        format!(
+          "{}.java",
+          case_util::auto_convert_case(&stem.to_string_lossy(), case_util::CaseType::Pascal)
+        )
+      }
       None => "Unknown.java".to_string(),
     },
   }
 }
 
-fn build_save_path(
+pub fn build_save_path(
   source_directory: &JavaSourceDirectoryType,
   cwd: &Path,
   package_name: &str,


### PR DESCRIPTION
This pull request refactors the Java file creation and JPA entity generation services to improve modularity, code clarity, and correctness. The changes focus on making utility functions public, enhancing file name normalization, and streamlining the process of generating, updating, and saving Java files for JPA entities.

**Refactoring and Modularity Improvements:**

* Made utility functions (`generate_file_template`, `create_ts_file`, `correct_java_file_name`, `build_save_path`) in `create_java_file_service.rs` public for broader reuse and added case conversion logic to `correct_java_file_name` for consistent PascalCase file naming.
* Updated imports in `create_jpa_entity_service.rs` to directly use the newly public functions from `create_java_file_service`, simplifying dependencies and improving code clarity.

**JPA Entity Generation Workflow Enhancements:**

* Refactored the entity creation workflow to generate and manipulate the Java file in-memory (as a `TSFile`) before saving, rather than loading from disk, improving efficiency and reducing I/O operations.
* Improved the file saving logic to use the corrected file name and dynamically build the save path, ensuring files are saved with proper naming conventions and in the correct directory.
* Streamlined the main `run` function for JPA entity creation to reflect the new workflow, updating the step-by-step process and ensuring consistency in file handling and annotation insertion.