### PR TITLE
Fix get_java_basic_types_command naming inconsistency

### DIFF
--- a/src/commands/get_java_basic_types_command.rs
+++ b/src/commands/get_java_basic_types_command.rs
@@ -11,7 +11,7 @@ pub fn execute(
   field_type_kind: &JavaBasicFieldTypeKind,
 ) -> Response<Vec<BasicJavaType>> {
   let cwd_string = cwd.display().to_string();
-  let cmd_name = String::from("get-id-field-types");
+  let cmd_name = String::from("get-java-basic-types");
   match run(field_type_kind) {
     Ok(types) => Response::success(cmd_name, cwd_string, types),
     Err(error_msg) => Response::error(cmd_name, cwd_string, error_msg),


### PR DESCRIPTION
This pull request addresses an issue with the naming of the `get_java_basic_types_command`. The command name was previously inconsistent with the established naming conventions used throughout the codebase. This update ensures that the command is properly named and aligned with the expected structure, improving clarity and maintainability.

By standardizing the command name, this change helps prevent confusion for developers and users interacting with the command interface. It also supports better discoverability and consistency across the codebase, reducing the likelihood of errors related to command invocation or registration. No functional logic has been altered beyond the renaming; all related references have been updated accordingly.