### PR TITLE
Implement get_java_files command to retrieve Java files

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ Syntaxpresso Core is designed as a backend service for IDE plugins, offering com
 - **`create-jpa-entity`**: Generate new JPA entity classes
 - **`get-jpa-entity-info`**: Extract detailed information from existing entities
 - **`get-all-packages`**: List all Java packages in the project
+- **`get-java-basic-types`**: List all supported Java basic field types (optionally filter for Id types)
 
 #### Field Generation
 
 - **`create-jpa-entity-basic-field`**: Add basic fields with JPA annotations
 - **`create-jpa-entity-id-field`**: Create ID fields with generation strategies
 - **`create-jpa-entity-enum-field`**: Add enum fields with proper JPA mapping
-- **`get-java-basic-types`**: List all supported Java basic field types (optionally filter for Id types)
 
 #### Relationship Management
 

--- a/src/commands/get_java_files_command.rs
+++ b/src/commands/get_java_files_command.rs
@@ -1,0 +1,20 @@
+use std::path::Path;
+
+use crate::{
+  commands::services::get_java_files_service::run,
+  common::types::java_file_type::JavaFileType,
+  responses::{get_files_response::GetFilesResponse, response::Response},
+};
+
+pub fn execute(cwd: &Path, file_type: &JavaFileType) -> Response<GetFilesResponse> {
+  let cwd_string = cwd.display().to_string();
+  let cmd_name = String::from("get-java-files");
+  match run(cwd, file_type) {
+    Ok(files) => {
+      let files_count = files.len();
+      let response = GetFilesResponse { files, files_count };
+      Response::success(cmd_name, cwd_string, response)
+    }
+    Err(error_msg) => Response::error(cmd_name, cwd_string, error_msg),
+  }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -10,6 +10,7 @@ pub mod get_all_jpa_entities_command;
 pub mod get_all_jpa_mapped_superclasses;
 pub mod get_all_packages_command;
 pub mod get_java_basic_types_command;
+pub mod get_java_files_command;
 pub mod get_jpa_entity_info_command;
 pub mod services;
 mod validators;
@@ -70,6 +71,13 @@ pub enum Commands {
 
     #[arg(long, default_value = "basic")]
     field_type_kind: JavaBasicFieldTypeKind,
+  },
+  GetJavaFiles {
+    #[arg(long, value_parser = validate_directory_unrestricted, required = true)]
+    cwd: PathBuf,
+
+    #[arg(long, required = true)]
+    file_type: JavaFileType,
   },
   CreateJavaFile {
     #[arg(long, value_parser = validate_directory_unrestricted, required = true)]
@@ -313,6 +321,10 @@ impl Commands {
       }
       Commands::GetJavaBasicTypes { cwd, field_type_kind } => {
         let response = get_java_basic_types_command::execute(cwd.as_path(), field_type_kind);
+        response.to_json_pretty().map_err(|e| e.into())
+      }
+      Commands::GetJavaFiles { cwd, file_type } => {
+        let response = get_java_files_command::execute(cwd.as_path(), file_type);
         response.to_json_pretty().map_err(|e| e.into())
       }
       Commands::CreateJavaFile { cwd, package_name, file_name, file_type, source_directory } => {

--- a/src/commands/services/get_java_files_service.rs
+++ b/src/commands/services/get_java_files_service.rs
@@ -1,0 +1,87 @@
+use std::path::Path;
+
+use crate::{
+  common::{
+    services::{
+      annotation_type_declaration_service::get_public_annotation_type_node,
+      class_declaration_service::get_public_class_node,
+      enum_declaration_service::get_public_enum_node,
+      interface_declaration_service::get_public_interface_node,
+      package_declaration_service::{get_package_declaration_node, get_package_scope_node},
+      record_declaration_service::get_public_record_node,
+    },
+    ts_file::TSFile,
+    types::{java_file_type::JavaFileType, java_source_directory_type::JavaSourceDirectoryType},
+    utils::path_util::parse_all_files,
+  },
+  responses::file_response::FileResponse,
+};
+
+fn create_file_response(ts_file: &TSFile) -> Option<FileResponse> {
+  let file_type = ts_file.get_file_name_without_ext().unwrap_or_else(|| "Unknown".to_string());
+  let file_path = ts_file
+    .file_path()
+    .map(|p| p.to_string_lossy().to_string())
+    .unwrap_or_else(|| "Unknown path".to_string());
+  let file_package_name = if let Some(package_node) = get_package_declaration_node(ts_file) {
+    get_package_scope_node(ts_file, package_node)
+      .and_then(|name_node| ts_file.get_text_from_node(&name_node))
+      .map(|s| s.to_string())
+      .unwrap_or_else(|| "No package".to_string())
+  } else {
+    return None;
+  };
+  let found_file = FileResponse { file_type, file_package_name, file_path };
+  Some(found_file)
+}
+
+pub fn run(cwd: &Path, java_file_type: &JavaFileType) -> Result<Vec<FileResponse>, String> {
+  let mut files: Vec<FileResponse> = Vec::new();
+  let ts_files = parse_all_files(cwd, &JavaSourceDirectoryType::Main);
+  for ts_file in ts_files {
+    match java_file_type {
+      JavaFileType::Class => match get_public_class_node(&ts_file) {
+        // TODO: is get_public_class_node falling back to non public classes?
+        Some(_) => {
+          if let Some(file_response) = create_file_response(&ts_file) {
+            files.push(file_response);
+          }
+        }
+        None => continue,
+      },
+      JavaFileType::Interface => match get_public_interface_node(&ts_file) {
+        Some(_) => {
+          if let Some(file_response) = create_file_response(&ts_file) {
+            files.push(file_response);
+          }
+        }
+        None => continue,
+      },
+      JavaFileType::Enum => match get_public_enum_node(&ts_file) {
+        Some(_) => {
+          if let Some(file_response) = create_file_response(&ts_file) {
+            files.push(file_response);
+          }
+        }
+        None => continue,
+      },
+      JavaFileType::Annotation => match get_public_annotation_type_node(&ts_file) {
+        Some(_) => {
+          if let Some(file_response) = create_file_response(&ts_file) {
+            files.push(file_response);
+          }
+        }
+        None => continue,
+      },
+      JavaFileType::Record => match get_public_record_node(&ts_file) {
+        Some(_) => {
+          if let Some(file_response) = create_file_response(&ts_file) {
+            files.push(file_response);
+          }
+        }
+        None => continue,
+      },
+    }
+  }
+  Ok(files)
+}

--- a/src/commands/services/mod.rs
+++ b/src/commands/services/mod.rs
@@ -10,4 +10,5 @@ pub mod get_all_jpa_entities_service;
 pub mod get_all_jpa_mapped_superclasses;
 pub mod get_all_packages_service;
 pub mod get_java_basic_types_service;
+pub mod get_java_files_service;
 pub mod get_jpa_entity_info_service;

--- a/src/common/services/annotation_type_declaration_service.rs
+++ b/src/common/services/annotation_type_declaration_service.rs
@@ -1,0 +1,87 @@
+#![allow(dead_code)]
+
+use crate::common::ts_file::TSFile;
+use tree_sitter::Node;
+
+pub fn find_annotation_type_node_by_name<'a>(
+  ts_file: &'a TSFile,
+  annotation_type_name: &str,
+) -> Option<Node<'a>> {
+  ts_file.tree.as_ref()?;
+  let query_string = format!(
+    r#"
+        (annotation_type_declaration
+          name: (identifier) @annotationName
+        (#eq? @annotationName "{}")) @annotationDeclaration
+        "#,
+    annotation_type_name
+  );
+  ts_file
+    .query_builder(&query_string)
+    .returning("annotationDeclaration")
+    .execute()
+    .ok()?
+    .first_node()
+}
+
+pub fn get_first_public_annotation_type_node<'a>(ts_file: &'a TSFile) -> Option<Node<'a>> {
+  ts_file.tree.as_ref()?;
+  let query_string = r#"
+        (annotation_type_declaration
+          (modifiers) @modifiers
+          name: (identifier) @annotationName
+        ) @annotationDeclaration
+    "#;
+  if let Ok(results) = ts_file.query_builder(query_string).returning_all_captures().execute() {
+    let captures = results.captures();
+    for capture_map in captures {
+      if let Some(modifiers_node) = capture_map.get("modifiers")
+        && let Some(modifier_text) = ts_file.get_text_from_node(modifiers_node)
+        && modifier_text.contains("public")
+      {
+        return capture_map.get("annotationDeclaration").copied();
+      }
+    }
+  }
+  None
+}
+
+pub fn get_public_annotation_type_node<'a>(ts_file: &'a TSFile) -> Option<Node<'a>> {
+  ts_file.tree.as_ref()?;
+  match ts_file.get_file_name_without_ext() {
+    Some(ref file_name) if !file_name.is_empty() => {
+      find_annotation_type_node_by_name(ts_file, file_name)
+    }
+    _ => get_first_public_annotation_type_node(ts_file),
+  }
+}
+
+pub fn get_annotation_type_name_node<'a>(
+  ts_file: &'a TSFile,
+  annotation_type_declaration_node: Node<'a>,
+) -> Option<Node<'a>> {
+  if ts_file.tree.is_none()
+    || annotation_type_declaration_node.kind() != "annotation_type_declaration"
+  {
+    return None;
+  }
+  let query_string = r#"
+        (annotation_type_declaration
+          name: (identifier) @annotationName
+        ) @annotationDeclaration
+    "#;
+  if let Ok(results) = ts_file
+    .query_builder(query_string)
+    .within(annotation_type_declaration_node)
+    .returning_all_captures()
+    .execute()
+  {
+    let captures = results.captures();
+    for capture_map in captures {
+      if let Some(name_node) = capture_map.get("annotationName") {
+        return Some(*name_node);
+      }
+    }
+  }
+  None
+}

--- a/src/common/services/enum_declaration_service.rs
+++ b/src/common/services/enum_declaration_service.rs
@@ -1,0 +1,75 @@
+#![allow(dead_code)]
+
+use crate::common::ts_file::TSFile;
+use tree_sitter::Node;
+
+pub fn find_enum_node_by_name<'a>(ts_file: &'a TSFile, enum_name: &str) -> Option<Node<'a>> {
+  ts_file.tree.as_ref()?;
+  let query_string = format!(
+    r#"
+        (enum_declaration
+          name: (identifier) @enumName
+        (#eq? @enumName "{}")) @enumDeclaration
+        "#,
+    enum_name
+  );
+  ts_file.query_builder(&query_string).returning("enumDeclaration").execute().ok()?.first_node()
+}
+
+pub fn get_first_public_enum_node<'a>(ts_file: &'a TSFile) -> Option<Node<'a>> {
+  ts_file.tree.as_ref()?;
+  let query_string = r#"
+        (enum_declaration
+          (modifiers) @modifiers
+          name: (identifier) @enumName
+        ) @enumDeclaration
+    "#;
+  if let Ok(results) = ts_file.query_builder(query_string).returning_all_captures().execute() {
+    let captures = results.captures();
+    for capture_map in captures {
+      if let Some(modifiers_node) = capture_map.get("modifiers")
+        && let Some(modifier_text) = ts_file.get_text_from_node(modifiers_node)
+        && modifier_text.contains("public")
+      {
+        return capture_map.get("enumDeclaration").copied();
+      }
+    }
+  }
+  None
+}
+
+pub fn get_public_enum_node<'a>(ts_file: &'a TSFile) -> Option<Node<'a>> {
+  ts_file.tree.as_ref()?;
+  match ts_file.get_file_name_without_ext() {
+    Some(ref file_name) if !file_name.is_empty() => find_enum_node_by_name(ts_file, file_name),
+    _ => get_first_public_enum_node(ts_file),
+  }
+}
+
+pub fn get_enum_name_node<'a>(
+  ts_file: &'a TSFile,
+  enum_declaration_node: Node<'a>,
+) -> Option<Node<'a>> {
+  if ts_file.tree.is_none() || enum_declaration_node.kind() != "enum_declaration" {
+    return None;
+  }
+  let query_string = r#"
+        (enum_declaration
+          name: (identifier) @enumName
+        ) @enumDeclaration
+    "#;
+  if let Ok(results) = ts_file
+    .query_builder(query_string)
+    .within(enum_declaration_node)
+    .returning_all_captures()
+    .execute()
+  {
+    let captures = results.captures();
+    for capture_map in captures {
+      if let Some(name_node) = capture_map.get("enumName") {
+        return Some(*name_node);
+      }
+    }
+  }
+  None
+}

--- a/src/common/services/mod.rs
+++ b/src/common/services/mod.rs
@@ -1,6 +1,9 @@
 pub mod annotation_service;
+pub mod annotation_type_declaration_service;
 pub mod class_declaration_service;
+pub mod enum_declaration_service;
 pub mod field_declaration_service;
 pub mod import_declaration_service;
 pub mod interface_declaration_service;
 pub mod package_declaration_service;
+pub mod record_declaration_service;

--- a/src/common/services/record_declaration_service.rs
+++ b/src/common/services/record_declaration_service.rs
@@ -1,0 +1,75 @@
+#![allow(dead_code)]
+
+use crate::common::ts_file::TSFile;
+use tree_sitter::Node;
+
+pub fn find_record_node_by_name<'a>(ts_file: &'a TSFile, record_name: &str) -> Option<Node<'a>> {
+  ts_file.tree.as_ref()?;
+  let query_string = format!(
+    r#"
+        (record_declaration
+          name: (identifier) @recordName
+        (#eq? @recordName "{}")) @recordDeclaration
+        "#,
+    record_name
+  );
+  ts_file.query_builder(&query_string).returning("recordDeclaration").execute().ok()?.first_node()
+}
+
+pub fn get_first_public_record_node<'a>(ts_file: &'a TSFile) -> Option<Node<'a>> {
+  ts_file.tree.as_ref()?;
+  let query_string = r#"
+        (record_declaration
+          (modifiers) @modifiers
+          name: (identifier) @recordName
+        ) @recordDeclaration
+    "#;
+  if let Ok(results) = ts_file.query_builder(query_string).returning_all_captures().execute() {
+    let captures = results.captures();
+    for capture_map in captures {
+      if let Some(modifiers_node) = capture_map.get("modifiers")
+        && let Some(modifier_text) = ts_file.get_text_from_node(modifiers_node)
+        && modifier_text.contains("public")
+      {
+        return capture_map.get("recordDeclaration").copied();
+      }
+    }
+  }
+  None
+}
+
+pub fn get_public_record_node<'a>(ts_file: &'a TSFile) -> Option<Node<'a>> {
+  ts_file.tree.as_ref()?;
+  match ts_file.get_file_name_without_ext() {
+    Some(ref file_name) if !file_name.is_empty() => find_record_node_by_name(ts_file, file_name),
+    _ => get_first_public_record_node(ts_file),
+  }
+}
+
+pub fn get_record_name_node<'a>(
+  ts_file: &'a TSFile,
+  record_declaration_node: Node<'a>,
+) -> Option<Node<'a>> {
+  if ts_file.tree.is_none() || record_declaration_node.kind() != "record_declaration" {
+    return None;
+  }
+  let query_string = r#"
+        (record_declaration
+          name: (identifier) @recordName
+        ) @recordDeclaration
+    "#;
+  if let Ok(results) = ts_file
+    .query_builder(query_string)
+    .within(record_declaration_node)
+    .returning_all_captures()
+    .execute()
+  {
+    let captures = results.captures();
+    for capture_map in captures {
+      if let Some(name_node) = capture_map.get("recordName") {
+        return Some(*name_node);
+      }
+    }
+  }
+  None
+}


### PR DESCRIPTION
This pull request introduces the `get_java_files_command` feature, which adds the ability to retrieve Java files within the project. The new command is implemented in `src/commands/get_java_files_command.rs` and is supported by a corresponding service in `src/commands/services/get_java_files_service.rs`. This enhancement enables users to programmatically list Java files, facilitating improved automation and integration with other tooling.

The motivation for this change is to streamline workflows that require access to Java source files, such as code generation, analysis, or refactoring operations. By providing a dedicated command for fetching Java files, the codebase becomes more modular and easier to extend for future features related to Java file management.

This update also aligns with the existing command and service architecture, ensuring consistency and maintainability across the project. No breaking changes are introduced, and the new functionality is encapsulated to avoid side effects on unrelated components.