### PR TITLE
feat: expose entity table name in get jpa entity info response

### DIFF
--- a/src/responses/get_jpa_entity_info_response.rs
+++ b/src/responses/get_jpa_entity_info_response.rs
@@ -6,6 +6,7 @@ use serde::Serialize;
 #[serde(rename_all = "camelCase")]
 pub struct GetJpaEntityInfoResponse {
   pub is_jpa_entity: bool,
+  pub entity_table_name: Option<String>,
   pub entity_type: String,
   pub entity_package_name: String,
   pub superclass_type: Option<String>,


### PR DESCRIPTION
## Summary

This PR merges the feature branch `117-add-entitytablename-for-get-jpa-entity-info-command` into `develop`. It enhances the JPA entity info command by exposing the mapped table name, allowing consumers to retrieve the value specified in the `@Table(name = "...")` annotation for JPA entities.

## Changes

- Added logic to extract the `name` value from the `@Table` annotation in the JPA entity info service.
- Updated the `GetJpaEntityInfoResponse` struct to include a new `entity_table_name` field (optional string).
- The entity info response now provides the mapped table name if present, improving downstream tooling and integrations that require knowledge of the physical table name.

## Technical Details

- The service uses utility functions to locate the `@Table` annotation and extract its `name` attribute from the parsed Java source.
- The new field is optional and will be `None` if the entity does not specify a `@Table(name = "...")` annotation.
- This change is backward compatible and does not affect existing consumers that do not rely on the new field.