### PR TITLE
feat: expose entity table name in jpa entity info response

### DIFF
--- a/src/responses/get_jpa_entity_info_response.rs
+++ b/src/responses/get_jpa_entity_info_response.rs
@@ -6,6 +6,7 @@ use serde::Serialize;
 #[serde(rename_all = "camelCase")]
 pub struct GetJpaEntityInfoResponse {
   pub is_jpa_entity: bool,
+  pub entity_table_name: Option<String>,
   pub entity_type: String,
   pub entity_package_name: String,
   pub superclass_type: Option<String>,


### PR DESCRIPTION
## Summary

This PR merges changes from the "develop" branch into "main", introducing the ability to extract and expose the mapped table name for JPA entities in the entity info response. This enhancement allows consumers to programmatically access the table name specified by the `@Table(name = "...")` annotation, improving the utility of the entity inspection features.

## Changes

- Added logic to extract the `name` value from the `@Table` annotation in JPA entity classes.
- Updated the `GetJpaEntityInfoResponse` struct to include a new `entity_table_name` field.
- Modified the entity info service to populate the `entity_table_name` field when available.
- Ensured the new field is included in the response for consumers of the get JPA entity info command.

## Technical Details

- The service now uses helper functions to locate the `@Table` annotation and extract its `name` attribute, if present.
- The new field is optional (`Option<String>`) to gracefully handle entities without a `@Table` annotation.
- This change is backward-compatible and does not affect existing consumers who do not rely on the table name.