### PR TITLE
feat: refactor UI forms to use command layer and standardize response output

### DIFF
--- a/src/responses/create_entity_field_response.rs
+++ b/src/responses/create_entity_field_response.rs
@@ -1,0 +1,9 @@
+use serde::Serialize;
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateEntityFieldResponse {
+  pub entity_file_path: String,
+  pub field_name: String,
+  pub field_type: String,
+}

--- a/src/responses/create_many_to_one_relationship_response.rs
+++ b/src/responses/create_many_to_one_relationship_response.rs
@@ -1,0 +1,12 @@
+use serde::Serialize;
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateManyToOneRelationshipResponse {
+  pub success: bool,
+  pub message: String,
+  pub owning_side_entity_path: String,
+  pub inverse_side_entity_path: Option<String>,
+  pub owning_side_updated: bool,
+  pub inverse_side_updated: bool,
+}

--- a/src/responses/mod.rs
+++ b/src/responses/mod.rs
@@ -1,6 +1,8 @@
 pub mod basic_java_type_response;
+pub mod create_entity_field_response;
 pub mod create_jpa_one_to_one_relationship_response;
 pub mod create_jpa_repository_response;
+pub mod create_many_to_one_relationship_response;
 pub mod error_response;
 pub mod file_response;
 pub mod get_files_response;

--- a/src/ui/forms/create_entity_field.rs
+++ b/src/ui/forms/create_entity_field.rs
@@ -372,7 +372,10 @@ impl FormBehavior for CreateEntityFieldForm {
     }
 
     // Handle Ctrl+Backspace (F2 signal) - not applicable for category selection (no back), delegate to child
-    if key == KeyCode::F(2) && self.phase == FormPhase::ChildForm && let Some(ref mut child) = self.child_form {
+    if key == KeyCode::F(2)
+      && self.phase == FormPhase::ChildForm
+      && let Some(ref mut child) = self.child_form
+    {
       let result = match child {
         ChildFormType::Basic(form) => form.handle_input(key),
         ChildFormType::Enum(form) => form.handle_input(key),
@@ -409,7 +412,9 @@ impl FormBehavior for CreateEntityFieldForm {
     }
 
     // Handle C-c
-    if let KeyCode::Char('c') = key && self.input_mode() == InputMode::Insert {
+    if let KeyCode::Char('c') = key
+      && self.input_mode() == InputMode::Insert
+    {
       self.set_input_mode(InputMode::Normal);
       self.escape_handler_mut().reset();
       return false;

--- a/src/ui/forms/create_entity_relationship.rs
+++ b/src/ui/forms/create_entity_relationship.rs
@@ -385,7 +385,10 @@ impl FormBehavior for CreateEntityRelationshipForm {
     }
 
     // Handle Ctrl+Backspace (F2 signal)
-    if key == KeyCode::F(2) && self.phase == FormPhase::ChildForm && let Some(ref mut child) = self.child_form {
+    if key == KeyCode::F(2)
+      && self.phase == FormPhase::ChildForm
+      && let Some(ref mut child) = self.child_form
+    {
       return match child {
         ChildFormType::OneToOne(form) => form.handle_input(key),
         ChildFormType::ManyToOne(form) => form.handle_input(key),
@@ -416,7 +419,9 @@ impl FormBehavior for CreateEntityRelationshipForm {
     }
 
     // Handle C-c
-    if let KeyCode::Char('c') = key && self.input_mode() == InputMode::Insert {
+    if let KeyCode::Char('c') = key
+      && self.input_mode() == InputMode::Insert
+    {
       self.set_input_mode(InputMode::Normal);
       self.escape_handler_mut().reset();
       return false;

--- a/src/ui/runner.rs
+++ b/src/ui/runner.rs
@@ -40,7 +40,9 @@ fn run_app<B: ratatui::backend::Backend, F: FormBehavior>(
   loop {
     terminal.draw(|f| app.render(f))?;
 
-    if let Event::Key(key) = event::read()? && key.kind == KeyEventKind::Press {
+    if let Event::Key(key) = event::read()?
+      && key.kind == KeyEventKind::Press
+    {
       if key.code == KeyCode::Char('c') && key.modifiers.contains(KeyModifiers::CONTROL) {
         if app.handle_input(KeyCode::Char('c')) {
           return Ok(());


### PR DESCRIPTION
## Summary

This PR merges the `update-communication-protocol` branch into `implement-rust-ui`. It introduces a dual-interface architecture for Syntaxpresso Core, refactors the UI forms to use a unified command layer and response output, and standardizes the request-response flow for both CLI and TUI interfaces. The changes improve maintainability, consistency, and extensibility of the codebase, while also enhancing error handling and developer documentation.

## Changes

- **Architecture & Documentation**
  - Expanded the README to document the new dual-interface (CLI and TUI) architecture.
  - Detailed the unidirectional request-response model, process flow, and stateless execution.
  - Added diagrams and step-by-step breakdowns of system layers and responsibilities.
  - Clarified key design decisions and response formats.

- **Response Types**
  - Added `CreateEntityFieldResponse` and `CreateManyToOneRelationshipResponse` structs for richer, more structured API responses.
  - Registered new response modules in `src/responses/mod.rs` for broader API support.

- **UI Refactor**
  - Refactored all UI form modules to invoke command layer functions instead of calling service modules directly.
  - Replaced inline result handling in forms with a new `helpers::output_response_and_exit` function, ensuring standardized JSON output and process exit.
  - Updated error and success handling to be consistent across all UI form execution paths.
  - Cleaned up imports to reflect new command usage and removed unused service imports.

- **Key Handling & Event Logic**
  - Improved key event matching and handling in `form_trait.rs` and `runner.rs` for clarity and maintainability.
  - Enhanced code formatting for multi-line conditional statements in form logic and event handling.

## Technical Details

- The new `output_response_and_exit` helper function serializes command responses to JSON, prints them to stdout, and exits the process with the appropriate status code (0 for success, 1 for error). This ensures both CLI and TUI interfaces provide identical, machine-readable output for frontend consumption.
- The command layer now acts as the single source of truth for building `Response<T>` objects, eliminating duplication and enforcing a consistent API.
- UI forms are now decoupled from business logic, calling only the command layer and handling responses in a uniform way.
- The architecture supports both programmatic CLI and interactive TUI flows, with a clear separation between UI, command, and service layers.
- All new and refactored code adheres to the stateless, one-request-per-process model, simplifying integration with IDE plugins and other frontends.