### PR TITLE
feat: add interactive tui forms and ui feature flag for code generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -183,30 +183,72 @@ jobs:
     strategy:
       matrix:
         include:
+          # CLI-only binaries (without UI feature)
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             platform: linux
             arch: amd64
             binary_name: syntaxpresso-core
             output_name: syntaxpresso-core-linux-amd64
+            features: ""
+            variant: "cli"
           - os: macos-15-intel
             target: x86_64-apple-darwin
             platform: macos
             arch: amd64
             binary_name: syntaxpresso-core
             output_name: syntaxpresso-core-macos-amd64
+            features: ""
+            variant: "cli"
           - os: macos-latest
             target: aarch64-apple-darwin
             platform: macos
             arch: arm64
             binary_name: syntaxpresso-core
             output_name: syntaxpresso-core-macos-arm64
+            features: ""
+            variant: "cli"
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             platform: windows
             arch: amd64
             binary_name: syntaxpresso-core.exe
             output_name: syntaxpresso-core-windows-amd64.exe
+            features: ""
+            variant: "cli"
+          # UI-enabled binaries (with UI feature)
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            platform: linux
+            arch: amd64
+            binary_name: syntaxpresso-core
+            output_name: syntaxpresso-core-ui-linux-amd64
+            features: "--features ui"
+            variant: "ui"
+          - os: macos-15-intel
+            target: x86_64-apple-darwin
+            platform: macos
+            arch: amd64
+            binary_name: syntaxpresso-core
+            output_name: syntaxpresso-core-ui-macos-amd64
+            features: "--features ui"
+            variant: "ui"
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            platform: macos
+            arch: arm64
+            binary_name: syntaxpresso-core
+            output_name: syntaxpresso-core-ui-macos-arm64
+            features: "--features ui"
+            variant: "ui"
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            platform: windows
+            arch: amd64
+            binary_name: syntaxpresso-core.exe
+            output_name: syntaxpresso-core-ui-windows-amd64.exe
+            features: "--features ui"
+            variant: "ui"
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code
@@ -232,7 +274,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --release --target ${{ matrix.target }}
+          args: --release --target ${{ matrix.target }} ${{ matrix.features }}
       - name: Rename binary for platform
         run: |
           if [ -f "target/${{ matrix.target }}/release/${{ matrix.binary_name }}" ]; then
@@ -262,7 +304,7 @@ jobs:
       - name: Upload binary as artifact
         uses: actions/upload-artifact@v4
         with:
-          name: binary-${{ matrix.platform }}-${{ matrix.arch }}
+          name: binary-${{ matrix.variant }}-${{ matrix.platform }}-${{ matrix.arch }}
           path: ${{ matrix.output_name }}
           retention-days: 1
   release:
@@ -298,14 +340,23 @@ jobs:
       - name: Prepare release files
         run: |
           mkdir -p release-files
-          cp binaries/binary-linux-amd64/syntaxpresso-core-linux-amd64 release-files/ || true
-          cp binaries/binary-macos-amd64/syntaxpresso-core-macos-amd64 release-files/ || true
-          cp binaries/binary-macos-arm64/syntaxpresso-core-macos-arm64 release-files/ || true
-          cp binaries/binary-windows-amd64/syntaxpresso-core-windows-amd64.exe release-files/ || true
+          # CLI-only binaries
+          cp binaries/binary-cli-linux-amd64/syntaxpresso-core-linux-amd64 release-files/ || true
+          cp binaries/binary-cli-macos-amd64/syntaxpresso-core-macos-amd64 release-files/ || true
+          cp binaries/binary-cli-macos-arm64/syntaxpresso-core-macos-arm64 release-files/ || true
+          cp binaries/binary-cli-windows-amd64/syntaxpresso-core-windows-amd64.exe release-files/ || true
+          # UI-enabled binaries
+          cp binaries/binary-ui-linux-amd64/syntaxpresso-core-ui-linux-amd64 release-files/ || true
+          cp binaries/binary-ui-macos-amd64/syntaxpresso-core-ui-macos-amd64 release-files/ || true
+          cp binaries/binary-ui-macos-arm64/syntaxpresso-core-ui-macos-arm64 release-files/ || true
+          cp binaries/binary-ui-windows-amd64/syntaxpresso-core-ui-windows-amd64.exe release-files/ || true
           # Make Unix binaries executable
           chmod +x release-files/syntaxpresso-core-linux-amd64 || true
           chmod +x release-files/syntaxpresso-core-macos-amd64 || true
           chmod +x release-files/syntaxpresso-core-macos-arm64 || true
+          chmod +x release-files/syntaxpresso-core-ui-linux-amd64 || true
+          chmod +x release-files/syntaxpresso-core-ui-macos-amd64 || true
+          chmod +x release-files/syntaxpresso-core-ui-macos-arm64 || true
           echo "Final release files with permissions:"
           ls -la release-files/
       - name: Create GitHub Release

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -47,7 +53,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -58,7 +64,7 @@ checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -72,6 +78,21 @@ name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+
+[[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "cc"
@@ -136,6 +157,143 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "compact_str"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb402b8d4c85569410425650ce3eddc7d698ed96d39a73f941b08fb63082f1e7"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "mio",
+ "parking_lot",
+ "rustix 0.38.44",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "derive_more",
+ "document-features",
+ "mio",
+ "parking_lot",
+ "rustix 1.1.2",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -148,7 +306,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -164,6 +322,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52051878f80a721bb68ebfbc930e07b65ba72f2da88968ea5c06fd6ca3d3a127"
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
 name = "getrandom"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -173,6 +343,17 @@ dependencies = [
  "libc",
  "r-efi",
  "wasip2",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
 ]
 
 [[package]]
@@ -188,13 +369,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "indexmap"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6717a8d2a5a929a1a2eb43a12812498ed141a0bcfb7e8f7844fbdbe4303bba9f"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.16.0",
+]
+
+[[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "instability"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435d80800b936787d62688c927b6490e887c7ef5ff9ce922c6c6050fca75eb9a"
+dependencies = [
+ "darling",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -202,6 +411,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -217,15 +435,63 @@ checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
+name = "log"
+version = "0.4.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+
+[[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
+]
 
 [[package]]
 name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+
+[[package]]
+name = "mio"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "once_cell"
@@ -238,6 +504,35 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "proc-macro2"
@@ -262,6 +557,36 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "ratatui"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+dependencies = [
+ "bitflags",
+ "cassowary",
+ "compact_str",
+ "crossterm 0.28.1",
+ "indoc",
+ "instability",
+ "itertools",
+ "lru",
+ "paste",
+ "strum",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
 
 [[package]]
 name = "regex"
@@ -294,6 +619,19 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
@@ -301,9 +639,15 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
- "windows-sys",
+ "linux-raw-sys 0.11.0",
+ "windows-sys 0.60.2",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
@@ -319,6 +663,12 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
@@ -371,6 +721,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -381,6 +773,28 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
 
 [[package]]
 name = "syn"
@@ -399,7 +813,9 @@ version = "0.4.3"
 dependencies = [
  "base64",
  "clap",
+ "crossterm 0.29.0",
  "heck",
+ "ratatui",
  "serde",
  "serde_json",
  "tempfile",
@@ -418,8 +834,8 @@ dependencies = [
  "fastrand",
  "getrandom",
  "once_cell",
- "rustix",
- "windows-sys",
+ "rustix 1.1.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -479,6 +895,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "462eeb75aeb73aea900253ce739c8e18a67423fadf006037cd3ff27e82748a06"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-truncate"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+dependencies = [
+ "itertools",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -495,6 +940,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
 name = "wasip2"
 version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -504,13 +955,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.60.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"
@@ -520,11 +993,45 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -534,15 +1041,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
  "windows-link",
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -552,9 +1065,21 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -564,9 +1089,21 @@ checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
 
 [[package]]
 name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -576,15 +1113,33 @@ checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
 
 [[package]]
 name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,18 @@ thiserror = "2.0.17"
 heck = "0.5.0"
 base64 = "0.22.1"
 
+# Optional UI dependencies (enabled with --features ui)
+ratatui = { version = "0.29", optional = true }
+crossterm = { version = "0.29.0", optional = true }
+
+[features]
+default = []
+ui = ["dep:ratatui", "dep:crossterm"]
+
 [dev-dependencies]
 tempfile = "3.8"
+
+[profile.release]
+strip = true
+lto = true
+codegen-units = 1

--- a/README.md
+++ b/README.md
@@ -16,9 +16,37 @@ A standalone Rust-based CLI backend for IDE plugins that provides advanced Java 
 
 Syntaxpresso Core is designed as a backend service for IDE plugins, offering comprehensive Java code generation and manipulation through a CLI interface. The tool specializes in JPA (Java Persistence API) entity management, providing developers with automated code generation for complex Java persistence scenarios.
 
+## Binary Variants
+
+Syntaxpresso Core is available in two variants:
+
+### CLI-only (Default)
+- Smaller binary size (~3.4MB)
+- Command-line interface with JSON output
+- Designed for IDE plugin integration
+- Binary names: `syntaxpresso-core-{platform}-{arch}`
+
+### UI-enabled
+- Includes interactive Terminal UI (TUI) for visual code generation
+- Built with the `ui` feature flag
+- Larger binary size (~4.0MB) due to UI dependencies
+- Binary names: `syntaxpresso-core-ui-{platform}-{arch}`
+
+### Choosing a Variant
+
+**Use CLI-only if:**
+- You're integrating with an IDE plugin (Neovim, VSCode, etc.)
+- You need JSON output for programmatic consumption
+- You want the smallest binary size
+
+**Use UI-enabled if:**
+- You want an interactive terminal interface for code generation
+- You prefer visual forms over command-line arguments
+- You're using it as a standalone tool
+
 ## Features
 
-### Available Commands
+### Available Commands (CLI)
 
 #### Entity Management
 
@@ -44,6 +72,58 @@ Syntaxpresso Core is designed as a backend service for IDE plugins, offering com
 
 - **`create-jpa-repository`**: Generate Spring Data JPA repository interfaces
 - **`create-java-file`**: Create basic Java files (classes, interfaces, enums)
+
+### UI Commands (UI-enabled binary only)
+
+The UI-enabled binary includes interactive terminal forms for:
+
+- **`ui java-file`**: Interactive form to create Java files
+- **`ui jpa-entity`**: Interactive form to create JPA entities
+- **`ui entity-field`**: Interactive form to add fields to entities
+- **`ui entity-relationship`**: Interactive form to create entity relationships
+
+```bash
+# Launch interactive UI for creating a Java file
+./syntaxpresso-core ui java-file --cwd /path/to/project
+
+# Launch UI to add a field to an entity
+./syntaxpresso-core ui entity-field \
+  --cwd /path/to/project \
+  --entity-file-path /path/to/User.java \
+  --entity-file-b64-src <base64-encoded-source>
+```
+
+## Installation
+
+### From GitHub Releases
+
+Download the appropriate binary for your platform from the [Releases page](https://github.com/syntaxpresso/core/releases):
+
+**CLI-only binaries:**
+- `syntaxpresso-core-linux-amd64` - Linux x86_64
+- `syntaxpresso-core-macos-amd64` - macOS Intel
+- `syntaxpresso-core-macos-arm64` - macOS Apple Silicon
+- `syntaxpresso-core-windows-amd64.exe` - Windows x86_64
+
+**UI-enabled binaries:**
+- `syntaxpresso-core-ui-linux-amd64` - Linux x86_64
+- `syntaxpresso-core-ui-macos-amd64` - macOS Intel
+- `syntaxpresso-core-ui-macos-arm64` - macOS Apple Silicon
+- `syntaxpresso-core-ui-windows-amd64.exe` - Windows x86_64
+
+### Building from Source
+
+**CLI-only:**
+```bash
+cargo build --release
+```
+
+**UI-enabled:**
+```bash
+cargo build --release --features ui
+```
+
+The binary will be available at `target/release/syntaxpresso-core`.
 
 ## Usage
 
@@ -135,12 +215,19 @@ src/
 ├── commands/           # CLI command implementations
 │   ├── services/       # Business logic services
 │   └── validators/     # Input validation
+├── ui/                 # Terminal UI (optional, requires 'ui' feature)
+│   ├── forms/          # Interactive form implementations
+│   └── widgets.rs      # Reusable UI components
 ├── common/
 │   ├── services/       # Shared services (annotations, imports, etc.)
 │   ├── types/          # Type definitions and configurations
 │   └── utils/          # Utility functions
 └── responses/          # Response type definitions
 ```
+
+### Feature Flags
+
+- `ui` - Enables the interactive Terminal UI commands (adds ~600KB to binary size)
 
 ### Prerequisites
 
@@ -149,8 +236,14 @@ src/
 
 ### Building
 
+**CLI-only:**
 ```bash
 cargo build
+```
+
+**With UI:**
+```bash
+cargo build --features ui
 ```
 
 ### Testing

--- a/src/commands/create_jpa_entity_basic_field_command.rs
+++ b/src/commands/create_jpa_entity_basic_field_command.rs
@@ -1,10 +1,7 @@
 use std::path::Path;
 
 use crate::{
-  commands::{
-    services::create_jpa_entity_basic_field_service::run,
-    validators::directory_validator::validate_file_path_within_base,
-  },
+  commands::services::create_jpa_entity_basic_field_service::run,
   common::types::basic_field_config::BasicFieldConfig,
   responses::{file_response::FileResponse, response::Response},
 };
@@ -17,17 +14,13 @@ pub fn execute(
 ) -> Response<FileResponse> {
   let cwd_string = cwd.display().to_string();
   let cmd_name = String::from("create-jpa-entity-basic-field");
-  // Security validation: ensure entity file path is within the cwd
-  let file_path_str = entity_file_path.display().to_string();
-  if let Err(error_msg) = validate_file_path_within_base(&file_path_str, cwd) {
-    return Response::error(
-      cmd_name,
-      cwd_string,
-      format!("Entity file path security validation failed: {}", error_msg),
-    );
-  }
 
-  match run(cwd, entity_file_b64_src, entity_file_path, field_config) {
+  // Note: We don't validate entity_file_path containment within cwd because
+  // we're editing an existing file that the user has opened, which may be
+  // located anywhere on the filesystem. The path is trusted as it comes from
+  // the user's editor context.
+
+  match run(entity_file_b64_src, entity_file_path, field_config) {
     Ok(response) => Response::success(cmd_name, cwd_string, response),
     Err(error_msg) => Response::error(cmd_name, cwd_string, error_msg),
   }

--- a/src/commands/create_jpa_repository_command.rs
+++ b/src/commands/create_jpa_repository_command.rs
@@ -2,10 +2,13 @@ use std::path::Path;
 
 use crate::{
   commands::{
-    services::create_jpa_repository_service::run,
+    services::create_jpa_repository_service::{run, run_with_manual_id},
     validators::directory_validator::validate_file_path_within_base,
   },
-  responses::{create_jpa_repository_response::CreateJPARepositoryResponse, response::Response},
+  responses::{
+    create_jpa_repository_response::CreateJPARepositoryResponse, file_response::FileResponse,
+    response::Response,
+  },
 };
 
 pub fn execute(
@@ -28,6 +31,39 @@ pub fn execute(
 
   match run(cwd, entity_file_b64_src, entity_file_path, b64_superclass_source) {
     Ok(response) => Response::success(cmd_name, cwd_string, response),
+    Err(error_msg) => Response::error(cmd_name, cwd_string, error_msg),
+  }
+}
+
+/// Creates a JPA repository with manually provided ID field information.
+/// This is used as a fallback when automatic ID field detection fails.
+pub fn execute_with_manual_id(
+  cwd: &Path,
+  entity_file_b64_src: &str,
+  entity_file_path: &Path,
+  id_field_type: &str,
+  id_field_package_name: &str,
+) -> Response<FileResponse> {
+  let cwd_string = cwd.display().to_string();
+  let cmd_name = String::from("create-jpa-repository-manual");
+  // Security validation: ensure entity file path is within the cwd
+  let file_path_str = entity_file_path.display().to_string();
+  if let Err(error_msg) = validate_file_path_within_base(&file_path_str, cwd) {
+    return Response::error(
+      cmd_name,
+      cwd_string,
+      format!("Entity file path security validation failed: {}", error_msg),
+    );
+  }
+
+  match run_with_manual_id(
+    cwd,
+    entity_file_b64_src,
+    entity_file_path,
+    id_field_type,
+    id_field_package_name,
+  ) {
+    Ok(file_response) => Response::success(cmd_name, cwd_string, file_response),
     Err(error_msg) => Response::error(cmd_name, cwd_string, error_msg),
   }
 }

--- a/src/commands/get_java_basic_types_command.rs
+++ b/src/commands/get_java_basic_types_command.rs
@@ -1,19 +1,13 @@
-use std::path::Path;
-
 use crate::{
   commands::services::get_java_basic_types_service::run,
   common::types::java_basic_types::JavaBasicType,
   responses::{basic_java_type_response::JavaBasicTypeResponse, response::Response},
 };
 
-pub fn execute(
-  cwd: &Path,
-  basic_type_kind: &JavaBasicType,
-) -> Response<Vec<JavaBasicTypeResponse>> {
-  let cwd_string = cwd.display().to_string();
+pub fn execute(basic_type_kind: &JavaBasicType) -> Response<Vec<JavaBasicTypeResponse>> {
   let cmd_name = String::from("get-java-basic-types");
   match run(basic_type_kind) {
-    Ok(types) => Response::success(cmd_name, cwd_string, types),
-    Err(error_msg) => Response::error(cmd_name, cwd_string, error_msg),
+    Ok(types) => Response::success(cmd_name, String::from("N/A"), types),
+    Err(error_msg) => Response::error(cmd_name, String::from("N/A"), error_msg),
   }
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -51,25 +51,18 @@ use crate::ui::{
 #[cfg(feature = "ui")]
 #[derive(Subcommand)]
 pub enum UiCommands {
-  JavaFile {
+  #[command(name = "create-java-file")]
+  CreateJavaFile {
     #[arg(long, value_parser = validate_directory_unrestricted, required = true)]
     cwd: PathBuf,
   },
-  JpaEntity {
+  #[command(name = "create-jpa-entity")]
+  CreateJpaEntity {
     #[arg(long, value_parser = validate_directory_unrestricted, required = true)]
     cwd: PathBuf,
   },
-  EntityField {
-    #[arg(long, value_parser = validate_directory_unrestricted, required = true)]
-    cwd: PathBuf,
-
-    #[arg(long, required = true)]
-    entity_file_b64_src: String,
-
-    #[arg(long, required = true)]
-    entity_file_path: PathBuf,
-  },
-  EntityRelationship {
+  #[command(name = "create-jpa-entity-basic-field")]
+  CreateJpaEntityBasicField {
     #[arg(long, value_parser = validate_directory_unrestricted, required = true)]
     cwd: PathBuf,
 
@@ -79,7 +72,19 @@ pub enum UiCommands {
     #[arg(long, required = true)]
     entity_file_path: PathBuf,
   },
-  JpaRepository {
+  #[command(name = "create-jpa-one-to-one-relationship")]
+  CreateJpaOneToOneRelationship {
+    #[arg(long, value_parser = validate_directory_unrestricted, required = true)]
+    cwd: PathBuf,
+
+    #[arg(long, required = true)]
+    entity_file_b64_src: String,
+
+    #[arg(long, required = true)]
+    entity_file_path: PathBuf,
+  },
+  #[command(name = "create-jpa-repository")]
+  CreateJpaRepository {
     #[arg(long, value_parser = validate_directory_unrestricted, required = true)]
     cwd: PathBuf,
 
@@ -95,17 +100,17 @@ pub enum UiCommands {
 impl UiCommands {
   pub fn execute(&self) -> Result<(), Box<dyn std::error::Error>> {
     match self {
-      UiCommands::JavaFile { cwd } => {
+      UiCommands::CreateJavaFile { cwd } => {
         let form = CreateJavaFileForm::new(cwd.clone());
         run_ui_command(form)?;
         Ok(())
       }
-      UiCommands::JpaEntity { cwd } => {
+      UiCommands::CreateJpaEntity { cwd } => {
         let form = CreateJpaEntityForm::new(cwd.clone());
         run_ui_command(form)?;
         Ok(())
       }
-      UiCommands::EntityField { cwd, entity_file_b64_src, entity_file_path } => {
+      UiCommands::CreateJpaEntityBasicField { cwd, entity_file_b64_src, entity_file_path } => {
         let form = CreateEntityFieldForm::new(
           cwd.clone(),
           entity_file_b64_src.clone(),
@@ -114,7 +119,7 @@ impl UiCommands {
         run_ui_command(form)?;
         Ok(())
       }
-      UiCommands::EntityRelationship { cwd, entity_file_b64_src, entity_file_path } => {
+      UiCommands::CreateJpaOneToOneRelationship { cwd, entity_file_b64_src, entity_file_path } => {
         let form = CreateEntityRelationshipForm::new(
           cwd.clone(),
           entity_file_b64_src.clone(),
@@ -123,7 +128,7 @@ impl UiCommands {
         run_ui_command(form)?;
         Ok(())
       }
-      UiCommands::JpaRepository { cwd, entity_file_b64_src, entity_file_path } => {
+      UiCommands::CreateJpaRepository { cwd, entity_file_b64_src, entity_file_path } => {
         let form = CreateJpaRepositoryForm::new(
           cwd.clone(),
           entity_file_b64_src.clone(),

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -43,7 +43,7 @@ use crate::ui::{
   forms::{
     create_entity_field::CreateEntityFieldForm,
     create_entity_relationship::CreateEntityRelationshipForm, create_java_file::CreateJavaFileForm,
-    create_jpa_entity::CreateJpaEntityForm,
+    create_jpa_entity::CreateJpaEntityForm, create_jpa_repository::CreateJpaRepositoryForm,
   },
   runner::run_ui_command,
 };
@@ -70,6 +70,16 @@ pub enum UiCommands {
     entity_file_path: PathBuf,
   },
   EntityRelationship {
+    #[arg(long, value_parser = validate_directory_unrestricted, required = true)]
+    cwd: PathBuf,
+
+    #[arg(long, required = true)]
+    entity_file_b64_src: String,
+
+    #[arg(long, required = true)]
+    entity_file_path: PathBuf,
+  },
+  JpaRepository {
     #[arg(long, value_parser = validate_directory_unrestricted, required = true)]
     cwd: PathBuf,
 
@@ -106,6 +116,15 @@ impl UiCommands {
       }
       UiCommands::EntityRelationship { cwd, entity_file_b64_src, entity_file_path } => {
         let form = CreateEntityRelationshipForm::new(
+          cwd.clone(),
+          entity_file_b64_src.clone(),
+          entity_file_path.clone(),
+        );
+        run_ui_command(form)?;
+        Ok(())
+      }
+      UiCommands::JpaRepository { cwd, entity_file_b64_src, entity_file_path } => {
+        let form = CreateJpaRepositoryForm::new(
           cwd.clone(),
           entity_file_b64_src.clone(),
           entity_file_path.clone(),

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -38,8 +38,91 @@ use crate::{
   },
 };
 
+#[cfg(feature = "ui")]
+use crate::ui::{
+  forms::{
+    create_entity_field::CreateEntityFieldForm,
+    create_entity_relationship::CreateEntityRelationshipForm, create_java_file::CreateJavaFileForm,
+    create_jpa_entity::CreateJpaEntityForm,
+  },
+  runner::run_ui_command,
+};
+
+#[cfg(feature = "ui")]
+#[derive(Subcommand)]
+pub enum UiCommands {
+  JavaFile {
+    #[arg(long, value_parser = validate_directory_unrestricted, required = true)]
+    cwd: PathBuf,
+  },
+  JpaEntity {
+    #[arg(long, value_parser = validate_directory_unrestricted, required = true)]
+    cwd: PathBuf,
+  },
+  EntityField {
+    #[arg(long, value_parser = validate_directory_unrestricted, required = true)]
+    cwd: PathBuf,
+
+    #[arg(long, required = true)]
+    entity_file_b64_src: String,
+
+    #[arg(long, required = true)]
+    entity_file_path: PathBuf,
+  },
+  EntityRelationship {
+    #[arg(long, value_parser = validate_directory_unrestricted, required = true)]
+    cwd: PathBuf,
+
+    #[arg(long, required = true)]
+    entity_file_b64_src: String,
+
+    #[arg(long, required = true)]
+    entity_file_path: PathBuf,
+  },
+}
+
+#[cfg(feature = "ui")]
+impl UiCommands {
+  pub fn execute(&self) -> Result<(), Box<dyn std::error::Error>> {
+    match self {
+      UiCommands::JavaFile { cwd } => {
+        let form = CreateJavaFileForm::new(cwd.clone());
+        run_ui_command(form)?;
+        Ok(())
+      }
+      UiCommands::JpaEntity { cwd } => {
+        let form = CreateJpaEntityForm::new(cwd.clone());
+        run_ui_command(form)?;
+        Ok(())
+      }
+      UiCommands::EntityField { cwd, entity_file_b64_src, entity_file_path } => {
+        let form = CreateEntityFieldForm::new(
+          cwd.clone(),
+          entity_file_b64_src.clone(),
+          entity_file_path.clone(),
+        );
+        run_ui_command(form)?;
+        Ok(())
+      }
+      UiCommands::EntityRelationship { cwd, entity_file_b64_src, entity_file_path } => {
+        let form = CreateEntityRelationshipForm::new(
+          cwd.clone(),
+          entity_file_b64_src.clone(),
+          entity_file_path.clone(),
+        );
+        run_ui_command(form)?;
+        Ok(())
+      }
+    }
+  }
+}
+
 #[derive(Subcommand)]
 pub enum Commands {
+  #[cfg(feature = "ui")]
+  #[command(subcommand)]
+  Ui(UiCommands),
+
   GetAllJPAEntities {
     #[arg(long, value_parser = validate_directory_unrestricted, required = true)]
     cwd: PathBuf,
@@ -66,9 +149,6 @@ pub enum Commands {
     source_directory: JavaSourceDirectoryType,
   },
   GetJavaBasicTypes {
-    #[arg(long, value_parser = validate_directory_unrestricted, required = true)]
-    cwd: PathBuf,
-
     #[arg(long, default_value = "all-types")]
     basic_type_kind: JavaBasicType,
   },
@@ -317,6 +397,11 @@ pub enum Commands {
 impl Commands {
   pub fn execute(&self) -> Result<String, Box<dyn std::error::Error>> {
     match self {
+      #[cfg(feature = "ui")]
+      Commands::Ui(ui_command) => {
+        ui_command.execute()?;
+        Ok(String::new())
+      }
       Commands::GetAllJPAEntities { cwd } => {
         let response = get_all_jpa_entities_command::execute(cwd.as_path());
         response.to_json_pretty().map_err(|e| e.into())
@@ -337,8 +422,8 @@ impl Commands {
         let response = get_all_packages_command::execute(cwd.as_path(), source_directory);
         response.to_json_pretty().map_err(|e| e.into())
       }
-      Commands::GetJavaBasicTypes { cwd, basic_type_kind } => {
-        let response = get_java_basic_types_command::execute(cwd.as_path(), basic_type_kind);
+      Commands::GetJavaBasicTypes { basic_type_kind } => {
+        let response = get_java_basic_types_command::execute(basic_type_kind);
         response.to_json_pretty().map_err(|e| e.into())
       }
       Commands::GetJavaFiles { cwd, file_type } => {

--- a/src/commands/services/create_jpa_entity_basic_field_service.rs
+++ b/src/commands/services/create_jpa_entity_basic_field_service.rs
@@ -194,7 +194,6 @@ fn build_file_response(ts_file: &TSFile) -> Result<FileResponse, String> {
 }
 
 pub fn run(
-  cwd: &Path,
   entity_file_b64_src: &str,
   entity_file_path: &Path,
   field_config: &BasicFieldConfig,
@@ -210,9 +209,9 @@ pub fn run(
   add_field_and_annotations(&mut entity_ts_file, field_config, &processed_field_config)?;
   // Step 5: Add imports
   add_imports(&mut entity_ts_file, &import_map);
-  // Step 6: Save file
+  // Step 6: Save file (use save_to_existing_file since we're modifying an existing entity file)
   entity_ts_file
-    .save_as(entity_file_path, cwd)
+    .save_to_existing_file(entity_file_path)
     .map_err(|e| format!("Unable to save JPA Entity file: {}", e))?;
   // Step 7: Build and return response
   build_file_response(&entity_ts_file)

--- a/src/commands/services/create_jpa_one_to_one_relationship_service.rs
+++ b/src/commands/services/create_jpa_one_to_one_relationship_service.rs
@@ -176,8 +176,6 @@ fn add_relationship_field_and_annotations(
     .ok_or_else(|| "Unable to get public class node from Entity".to_string())?;
   let public_class_node_start_byte = public_class_node.start_byte();
   let field_name_camel_case = case_util::auto_convert_case(field_name, CaseType::Camel);
-  let target_field_name_snake_case =
-    case_util::auto_convert_case(target_entity_type, CaseType::Snake);
   let params = AddFieldDeclarationParams {
     insertion_position: FieldInsertionPosition::EndOfClassBody,
     visibility_modifier: JavaVisibilityModifier::Private,
@@ -201,12 +199,13 @@ fn add_relationship_field_and_annotations(
       builder.with_argument("@OneToOne", "orphanRemoval", "true")?;
     }
     if let Some(ref mapped_by_field) = annotation_config.mapped_by_field {
-      let mapped_by_snake_case = case_util::auto_convert_case(mapped_by_field, CaseType::Snake);
-      builder.with_argument("@OneToOne", "mappedBy", &format!("\"{}\"", mapped_by_snake_case))?;
+      builder.with_argument("@OneToOne", "mappedBy", &format!("\"{}\"", mapped_by_field))?;
     }
     if annotation_config.needs_join_column {
       builder.add_annotation("@JoinColumn")?;
-      let column_name = format!("{}_id", target_field_name_snake_case);
+      let field_name_snake_case =
+        case_util::auto_convert_case(&field_name_camel_case, CaseType::Snake);
+      let column_name = format!("{}_id", field_name_snake_case);
       builder.with_argument("@JoinColumn", "name", &format!("\"{}\"", column_name))?;
       if is_mandatory {
         builder.with_argument("@JoinColumn", "nullable", "false")?;

--- a/src/commands/services/get_jpa_entity_info_service.rs
+++ b/src/commands/services/get_jpa_entity_info_service.rs
@@ -10,7 +10,7 @@ use crate::common::services::class_declaration_service::{
   get_class_declaration_name_node, get_class_superclass_name_node,
 };
 use crate::common::services::package_declaration_service::{
-  get_package_class_scope_node, get_package_declaration_node,
+  get_package_declaration_node, get_package_scope_node,
 };
 use crate::common::services::{
   annotation_service, class_declaration_service, field_declaration_service,
@@ -64,7 +64,7 @@ fn extract_entity_package_scope(ts_file: &TSFile) -> Result<String, String> {
     return Err("Unable to get package declaration node".to_string());
   }
   let package_declaration_node = package_declaration_node_option.unwrap();
-  let package_scope_node_option = get_package_class_scope_node(ts_file, package_declaration_node);
+  let package_scope_node_option = get_package_scope_node(ts_file, package_declaration_node);
   if package_scope_node_option.is_none() {
     return Err("Unable to get package scope".to_string());
   }

--- a/src/common/ts_file.rs
+++ b/src/common/ts_file.rs
@@ -295,7 +295,7 @@ impl TSFile {
   ///
   /// # fn main() -> std::io::Result<()> {
   /// let mut ts_file = TSFile::from_source_code("public class Example {}");
-  /// 
+  ///
   /// // Use system temp directory for portability
   /// let temp_dir = std::env::temp_dir();
   /// let existing_file = temp_dir.join("Example.java");

--- a/src/common/ts_file.rs
+++ b/src/common/ts_file.rs
@@ -291,14 +291,16 @@ impl TSFile {
   ///
   /// # Examples
   /// ```
-  /// use std::path::Path;
   /// use syntaxpresso_core::common::ts_file::TSFile;
   ///
   /// # fn main() -> std::io::Result<()> {
   /// let mut ts_file = TSFile::from_source_code("public class Example {}");
-  /// let existing_file = Path::new("/home/user/project/Example.java");
+  /// 
+  /// // Use system temp directory for portability
+  /// let temp_dir = std::env::temp_dir();
+  /// let existing_file = temp_dir.join("Example.java");
   ///
-  /// ts_file.save_to_existing_file(existing_file)?;
+  /// ts_file.save_to_existing_file(&existing_file)?;
   /// # Ok(())
   /// # }
   /// ```

--- a/src/common/ts_file.rs
+++ b/src/common/ts_file.rs
@@ -271,6 +271,55 @@ impl TSFile {
     Ok(())
   }
 
+  /// Save to an existing file path without security validation
+  ///
+  /// This method is intended for overwriting existing files that were passed in from external sources
+  /// (e.g., when editing a file opened by the user). It does NOT perform path traversal validation
+  /// and should only be used when the path comes from a trusted source.
+  ///
+  /// # Arguments
+  /// * `path` - The target file path to save to (must be absolute)
+  ///
+  /// # Returns
+  /// * `Ok(())` - If the file was successfully saved
+  /// * `Err(std::io::Error)` - If the file save fails
+  ///
+  /// # Safety Considerations
+  /// - This method bypasses security validation
+  /// - Only use for paths that come from trusted sources (e.g., user-opened files)
+  /// - The path should be absolute to avoid ambiguity
+  ///
+  /// # Examples
+  /// ```
+  /// use std::path::Path;
+  /// use syntaxpresso_core::common::ts_file::TSFile;
+  ///
+  /// # fn main() -> std::io::Result<()> {
+  /// let mut ts_file = TSFile::from_source_code("public class Example {}");
+  /// let existing_file = Path::new("/home/user/project/Example.java");
+  ///
+  /// ts_file.save_to_existing_file(existing_file)?;
+  /// # Ok(())
+  /// # }
+  /// ```
+  pub fn save_to_existing_file(&mut self, path: &Path) -> std::io::Result<()> {
+    // Validate that the path is absolute for safety
+    if !path.is_absolute() {
+      return Err(std::io::Error::other(format!(
+        "Path must be absolute when using save_to_existing_file: '{}'",
+        path.display()
+      )));
+    }
+    // Create parent directories if they don't exist
+    if let Some(parent) = path.parent() {
+      fs::create_dir_all(parent)?;
+    }
+    fs::write(path, &self.source_code)?;
+    self.file = Some(path.to_path_buf());
+    self.modified = false;
+    Ok(())
+  }
+
   /// Move file to new destination
   pub fn move_file(&mut self, destination: &Path) {
     self.new_path = Some(destination.to_path_buf());

--- a/src/common/utils/path_security_util.rs
+++ b/src/common/utils/path_security_util.rs
@@ -20,17 +20,16 @@ pub enum SecurityEvent {
 
 /// Log a security event to stderr for audit purposes
 /// This provides a simple audit trail without requiring external logging dependencies
+/// Note: Only logs failures and security concerns, not successful validations (to avoid noise)
 fn log_security_event(event: &SecurityEvent) {
   let timestamp = std::time::SystemTime::now()
     .duration_since(std::time::UNIX_EPOCH)
     .unwrap_or_else(|_| std::time::Duration::from_secs(0))
     .as_secs();
   match event {
-    SecurityEvent::PathValidationSuccess { target_path, base_path } => {
-      eprintln!(
-        "[SECURITY] [{}] Path validation SUCCESS: '{}' within base '{}'",
-        timestamp, target_path, base_path
-      );
+    SecurityEvent::PathValidationSuccess { .. } => {
+      // Don't log successful validations to avoid cluttering output
+      // Uncomment for debugging: eprintln!("[SECURITY] [{}] Path validation SUCCESS: '{}' within base '{}'", timestamp, target_path, base_path);
     }
     SecurityEvent::PathValidationFailure { target_path, base_path, reason } => {
       eprintln!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,6 @@
 pub mod commands;
 pub mod common;
 pub mod responses;
+
+#[cfg(feature = "ui")]
+pub mod ui;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,6 @@
-pub mod commands;
-pub mod common;
-pub mod responses;
-
 use clap::Parser;
-use commands::Commands;
-
-use crate::responses::error_response::ErrorResponse;
+use syntaxpresso_core::commands::Commands;
+use syntaxpresso_core::responses::error_response::ErrorResponse;
 
 #[derive(Parser)]
 #[command(name = "syntaxpresso-core")]

--- a/src/responses/create_entity_field_response.rs
+++ b/src/responses/create_entity_field_response.rs
@@ -1,0 +1,9 @@
+use serde::Serialize;
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateEntityFieldResponse {
+  pub entity_file_path: String,
+  pub field_name: String,
+  pub field_type: String,
+}

--- a/src/responses/create_many_to_one_relationship_response.rs
+++ b/src/responses/create_many_to_one_relationship_response.rs
@@ -1,0 +1,12 @@
+use serde::Serialize;
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateManyToOneRelationshipResponse {
+  pub success: bool,
+  pub message: String,
+  pub owning_side_entity_path: String,
+  pub inverse_side_entity_path: Option<String>,
+  pub owning_side_updated: bool,
+  pub inverse_side_updated: bool,
+}

--- a/src/responses/mod.rs
+++ b/src/responses/mod.rs
@@ -1,6 +1,8 @@
 pub mod basic_java_type_response;
+pub mod create_entity_field_response;
 pub mod create_jpa_one_to_one_relationship_response;
 pub mod create_jpa_repository_response;
+pub mod create_many_to_one_relationship_response;
 pub mod error_response;
 pub mod file_response;
 pub mod get_files_response;

--- a/src/ui/form_trait.rs
+++ b/src/ui/form_trait.rs
@@ -1,0 +1,365 @@
+#![allow(dead_code)]
+
+use crossterm::event::KeyCode;
+use ratatui::{Frame, widgets::ListState};
+
+/// Vim-style input mode
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum InputMode {
+  Normal,
+  Insert,
+}
+
+/// Helper for handling Esc-Esc quit pattern
+pub struct EscapeHandler {
+  pub pressed_once: bool,
+}
+
+impl EscapeHandler {
+  pub fn new() -> Self {
+    Self { pressed_once: false }
+  }
+
+  /// Returns true if should quit
+  pub fn handle_escape(&mut self, input_mode: InputMode) -> (bool, InputMode) {
+    match input_mode {
+      InputMode::Insert => {
+        // In Insert mode: Esc exits to Normal mode
+        (false, InputMode::Normal)
+      }
+      InputMode::Normal => {
+        // In Normal mode: Esc twice to quit
+        if self.pressed_once {
+          (true, InputMode::Normal) // Quit
+        } else {
+          self.pressed_once = true;
+          (false, InputMode::Normal)
+        }
+      }
+    }
+  }
+
+  pub fn reset(&mut self) {
+    self.pressed_once = false;
+  }
+}
+
+impl Default for EscapeHandler {
+  fn default() -> Self {
+    Self::new()
+  }
+}
+
+/// Common form state that all forms should embed
+pub struct FormState {
+  pub input_mode: InputMode,
+  pub escape_handler: EscapeHandler,
+  pub should_quit: bool,
+  pub error_message: Option<String>,
+}
+
+impl FormState {
+  pub fn new() -> Self {
+    Self {
+      input_mode: InputMode::Insert, // Start in Insert mode
+      escape_handler: EscapeHandler::new(),
+      should_quit: false,
+      error_message: None,
+    }
+  }
+}
+
+impl Default for FormState {
+  fn default() -> Self {
+    Self::new()
+  }
+}
+
+/// Trait for common form behavior
+/// All TUI forms should implement this trait to get shared functionality
+pub trait FormBehavior {
+  // ===== Required methods (must be implemented by each form) =====
+
+  /// Get reference to the common form state
+  fn form_state(&self) -> &FormState;
+
+  /// Get mutable reference to the common form state
+  fn form_state_mut(&mut self) -> &mut FormState;
+
+  /// Move focus to the next field (form-specific)
+  fn focus_next(&mut self);
+
+  /// Move focus to the previous field (form-specific)
+  fn focus_prev(&mut self);
+
+  /// Called when entering insert mode (form-specific setup)
+  /// The key parameter is either 'i' or 'a' to allow different behavior
+  fn on_enter_insert_mode(&mut self, key: KeyCode);
+
+  /// Called when Enter is pressed in Normal mode (form-specific)
+  fn on_enter_pressed(&mut self);
+
+  /// Handle field-specific input in Insert mode (form-specific)
+  fn handle_field_insert(&mut self, key: KeyCode);
+
+  /// Render the form (form-specific)
+  fn render(&mut self, frame: &mut Frame);
+
+  // ===== Default implementations (inherited by all forms) =====
+
+  /// Get the current input mode
+  fn input_mode(&self) -> InputMode {
+    self.form_state().input_mode
+  }
+
+  /// Set the input mode
+  fn set_input_mode(&mut self, mode: InputMode) {
+    self.form_state_mut().input_mode = mode;
+  }
+
+  /// Get mutable reference to escape handler
+  fn escape_handler_mut(&mut self) -> &mut EscapeHandler {
+    &mut self.form_state_mut().escape_handler
+  }
+
+  /// Handle input in Normal mode - DEFAULT IMPLEMENTATION
+  /// Common navigation: j/k/Tab for focus, i/a for insert mode, Enter to confirm
+  /// Forms can override this if they need different behavior
+  fn handle_normal_mode(&mut self, key: KeyCode) {
+    match key {
+      // Vim-style navigation
+      KeyCode::Char('j') | KeyCode::Tab => self.focus_next(),
+      KeyCode::Char('k') | KeyCode::BackTab => self.focus_prev(),
+      // Enter insert mode
+      KeyCode::Char('i') | KeyCode::Char('a') => {
+        self.on_enter_insert_mode(key);
+        self.set_input_mode(InputMode::Insert);
+      }
+      // Confirm action
+      KeyCode::Enter => self.on_enter_pressed(),
+      // Let forms handle other keys (like Up/Down for lists)
+      _ => {}
+    }
+  }
+
+  /// Handle input in Insert mode - DEFAULT IMPLEMENTATION
+  /// Delegates to field-specific input handling
+  /// Forms can override this if they need different behavior
+  fn handle_insert_mode(&mut self, key: KeyCode) {
+    self.handle_field_insert(key);
+  }
+
+  /// Main input handler - handles Esc, quit, and mode dispatching
+  /// This is the "inherited" behavior that all forms get automatically
+  fn handle_input(&mut self, key: KeyCode) -> bool {
+    // Handle Esc key
+    if let KeyCode::Esc = key {
+      let mode = self.input_mode();
+      let (should_quit, new_mode) = self.escape_handler_mut().handle_escape(mode);
+      self.set_input_mode(new_mode);
+      if should_quit {
+        return true;
+      }
+      return false;
+    }
+    // Handle C-c
+    if let KeyCode::Char('c') = key && self.input_mode() == InputMode::Insert {
+      self.set_input_mode(InputMode::Normal);
+      self.escape_handler_mut().reset();
+      return false;
+    }
+    // Reset escape handler on any other key
+    self.escape_handler_mut().reset();
+    // Dispatch to mode-specific handler
+    match self.input_mode() {
+      InputMode::Normal => self.handle_normal_mode(key),
+      InputMode::Insert => self.handle_insert_mode(key),
+    }
+    false // Don't quit
+  }
+
+  /// Generate a title with mode indicator
+  fn generate_title(&self, title: &str, is_focused: bool) -> String {
+    if is_focused && self.input_mode() == InputMode::Insert {
+      format!("{} -- INSERT --", title)
+    } else if is_focused {
+      format!("{} -- NORMAL --", title)
+    } else {
+      title.to_string()
+    }
+  }
+
+  /// Navigate through a list with up/down keys
+  fn navigate_list(&mut self, key: &KeyCode, state: &mut ListState, len: usize) {
+    let i = match state.selected() {
+      Some(i) => match key {
+        KeyCode::Up | KeyCode::Char('k') => {
+          if i == 0 {
+            len - 1
+          } else {
+            i - 1
+          }
+        }
+        KeyCode::Down | KeyCode::Char('j') => {
+          if i >= len - 1 {
+            0
+          } else {
+            i + 1
+          }
+        }
+        _ => i,
+      },
+      None => 0,
+    };
+    state.select(Some(i));
+  }
+
+  /// Handle standard navigation keys in Normal mode
+  /// Returns true if the key was handled
+  fn handle_standard_navigation(
+    &mut self,
+    key: KeyCode,
+    on_next: impl FnOnce(&mut Self),
+    on_prev: impl FnOnce(&mut Self),
+  ) -> bool {
+    match key {
+      KeyCode::Char('j') | KeyCode::Tab => {
+        on_next(self);
+        true
+      }
+      KeyCode::Char('k') | KeyCode::BackTab => {
+        on_prev(self);
+        true
+      }
+      KeyCode::Char('i') | KeyCode::Char('a') => {
+        self.set_input_mode(InputMode::Insert);
+        true
+      }
+      _ => false,
+    }
+  }
+}
+
+pub mod helpers {
+  use crossterm::event::KeyCode;
+  use ratatui::widgets::ListState;
+
+  use super::InputMode;
+
+  /// Navigate a list - standalone function
+  pub fn navigate_list_static(key: &KeyCode, state: &mut ListState, len: usize) {
+    let i = match state.selected() {
+      Some(i) => match key {
+        KeyCode::Up => {
+          if i == 0 {
+            len - 1
+          } else {
+            i - 1
+          }
+        }
+        KeyCode::Down => {
+          if i >= len - 1 {
+            0
+          } else {
+            i + 1
+          }
+        }
+        _ => i,
+      },
+      None => 0,
+    };
+    state.select(Some(i));
+  }
+
+  /// Handle text input (any characters allowed)
+  pub fn handle_text_input(
+    key: KeyCode,
+    text: &mut String,
+    cursor: &mut usize,
+    mode: &mut InputMode,
+  ) {
+    match key {
+      KeyCode::Char(c) => {
+        text.insert(*cursor, c);
+        *cursor += 1;
+      }
+      KeyCode::Backspace => {
+        if *cursor > 0 {
+          text.remove(*cursor - 1);
+          *cursor -= 1;
+        }
+      }
+      KeyCode::Delete => {
+        if *cursor < text.len() {
+          text.remove(*cursor);
+        }
+      }
+      KeyCode::Left => {
+        if *cursor > 0 {
+          *cursor -= 1;
+        }
+      }
+      KeyCode::Right => {
+        if *cursor < text.len() {
+          *cursor += 1;
+        }
+      }
+      KeyCode::Home => {
+        *cursor = 0;
+      }
+      KeyCode::End => {
+        *cursor = text.len();
+      }
+      KeyCode::Enter => {
+        *mode = InputMode::Normal;
+      }
+      _ => {}
+    }
+  }
+
+  /// Handle numeric input (only digits allowed)
+  pub fn handle_numeric_input(
+    key: KeyCode,
+    text: &mut String,
+    cursor: &mut usize,
+    mode: &mut InputMode,
+  ) {
+    match key {
+      KeyCode::Char(c) if c.is_ascii_digit() => {
+        text.insert(*cursor, c);
+        *cursor += 1;
+      }
+      KeyCode::Backspace => {
+        if *cursor > 0 {
+          text.remove(*cursor - 1);
+          *cursor -= 1;
+        }
+      }
+      KeyCode::Delete => {
+        if *cursor < text.len() {
+          text.remove(*cursor);
+        }
+      }
+      KeyCode::Left => {
+        if *cursor > 0 {
+          *cursor -= 1;
+        }
+      }
+      KeyCode::Right => {
+        if *cursor < text.len() {
+          *cursor += 1;
+        }
+      }
+      KeyCode::Home => {
+        *cursor = 0;
+      }
+      KeyCode::End => {
+        *cursor = text.len();
+      }
+      KeyCode::Enter => {
+        *mode = InputMode::Normal;
+      }
+      _ => {}
+    }
+  }
+}

--- a/src/ui/forms/create_basic_field.rs
+++ b/src/ui/forms/create_basic_field.rs
@@ -1,0 +1,1095 @@
+#![allow(dead_code)]
+
+use clap::ValueEnum;
+use crossterm::event::KeyCode;
+use ratatui::{
+  Frame,
+  layout::{Alignment, Constraint, Direction, Layout, Rect},
+  style::{Color, Modifier, Style},
+  widgets::{Block, Borders, List, ListItem, ListState, Paragraph},
+};
+use std::path::PathBuf;
+
+use crate::commands::get_java_basic_types_command;
+use crate::commands::services::create_jpa_entity_basic_field_service;
+use crate::common::types::basic_field_config::BasicFieldConfig;
+use crate::common::types::java_basic_types::JavaBasicType;
+use crate::common::types::java_field_temporal::JavaFieldTemporal;
+use crate::common::types::java_field_time_zone_storage::JavaFieldTimeZoneStorage;
+use crate::responses::basic_java_type_response::JavaBasicTypeResponse;
+use crate::ui::form_trait::{FormBehavior, FormState, InputMode, helpers};
+
+/// Represents which field is currently focused
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum FocusedField {
+  FieldType,
+  FieldName,
+  FieldLength,
+  TimeZoneStorage,
+  Temporal,
+  PrecisionAndScale,
+  OtherOptions,
+  BackButton,
+  ConfirmButton,
+}
+
+/// Main form state for creating a basic field
+pub struct CreateBasicFieldForm {
+  // Common form state (embedded)
+  state: FormState,
+
+  // Field values
+  field_type_index: usize,
+  field_package_path: Option<String>,
+  field_type: String,
+  field_name: String,
+  field_length: String,
+  field_precision: String,
+  field_scale: String,
+  time_zone_storage_index: Option<usize>,
+  temporal_index: Option<usize>,
+
+  // Other options (checkboxes)
+  mandatory: bool,
+  unique: bool,
+  large_object: bool,
+
+  // Type lists and metadata
+  all_types: Vec<JavaBasicTypeResponse>,
+  types_with_length: Vec<String>,
+  types_with_time_zone_storage: Vec<String>,
+  types_with_temporal: Vec<String>,
+  types_with_extra_other: Vec<String>,
+  types_with_precision_and_scale: Vec<String>,
+
+  // List states
+  field_type_state: ListState,
+  time_zone_storage_state: ListState,
+  temporal_state: ListState,
+  other_options_state: ListState,
+
+  // Text input states
+  field_name_cursor: usize,
+  field_length_cursor: usize,
+  field_precision_cursor: usize,
+  field_scale_cursor: usize,
+
+  // Visibility flags
+  field_length_hidden: bool,
+  field_temporal_hidden: bool,
+  field_time_zone_storage_hidden: bool,
+  field_scale_hidden: bool,
+  field_precision_hidden: bool,
+  other_extra_hidden: bool,
+  other_hidden: bool,
+
+  // Focus management
+  focused_field: FocusedField,
+
+  // Integration with syntaxpresso-core
+  cwd: PathBuf,
+  entity_file_b64_src: String,
+  entity_file_path: PathBuf,
+
+  // Navigation
+  should_go_back: bool,
+  back_pressed_once: bool,
+}
+
+impl CreateBasicFieldForm {
+  pub fn new(cwd: PathBuf, entity_file_b64_src: String, entity_file_path: PathBuf) -> Self {
+    // Fetch all types from syntaxpresso-core
+    // Try to fetch types from syntaxpresso-core, fall back to defaults if it fails
+    let type_data = match Self::fetch_type_data() {
+      Ok(data) => data,
+      Err(_e) => Self::get_default_type_data(),
+    };
+
+    // If still no types (shouldn't happen with defaults), use defaults as last resort
+    let type_data =
+      if type_data.all_types.is_empty() { Self::get_default_type_data() } else { type_data };
+
+    // ASSERTION: Verify we have types
+    assert!(!type_data.all_types.is_empty(), "type_data.all_types must not be empty!");
+
+    let mut field_type_state = ListState::default();
+    field_type_state.select(Some(0));
+
+    let mut time_zone_storage_state = ListState::default();
+    time_zone_storage_state.select(Some(0));
+
+    let mut temporal_state = ListState::default();
+    temporal_state.select(Some(0));
+
+    let mut other_options_state = ListState::default();
+    other_options_state.select(Some(0));
+
+    // Default to String type
+    let (default_package, default_type) = if !type_data.all_types.is_empty() {
+      (type_data.all_types[0].package_path.clone(), type_data.all_types[0].name.clone())
+    } else {
+      (Some("java.lang".to_string()), "String".to_string())
+    };
+
+    let mut form = Self {
+      state: FormState::new(),
+      field_type_index: 0,
+      field_package_path: default_package,
+      field_type: default_type,
+      field_name: String::new(),
+      field_length: "255".to_string(),
+      field_precision: "19".to_string(),
+      field_scale: "2".to_string(),
+      time_zone_storage_index: Some(0),
+      temporal_index: Some(0),
+      mandatory: false,
+      unique: false,
+      large_object: false,
+      all_types: type_data.all_types,
+      types_with_length: type_data.types_with_length,
+      types_with_time_zone_storage: type_data.types_with_time_zone_storage,
+      types_with_temporal: type_data.types_with_temporal,
+      types_with_extra_other: type_data.types_with_extra_other,
+      types_with_precision_and_scale: type_data.types_with_precision_and_scale,
+      field_type_state,
+      time_zone_storage_state,
+      temporal_state,
+      other_options_state,
+      field_name_cursor: 0,
+      field_length_cursor: 3,
+      field_precision_cursor: 2,
+      field_scale_cursor: 1,
+      field_length_hidden: false,
+      field_temporal_hidden: true,
+      field_time_zone_storage_hidden: true,
+      field_scale_hidden: true,
+      field_precision_hidden: true,
+      other_extra_hidden: false,
+      other_hidden: true,
+      focused_field: FocusedField::FieldType,
+      cwd,
+      entity_file_b64_src,
+      entity_file_path,
+      should_go_back: false,
+      back_pressed_once: false,
+    };
+
+    // Update field type to set correct visibility flags
+    form.update_field_type();
+
+    form
+  }
+
+  /// Get default fallback type data when fetching fails
+  fn get_default_type_data() -> TypeData {
+    TypeData {
+      all_types: vec![
+        JavaBasicTypeResponse {
+          id: "java.lang.String".to_string(),
+          name: "String".to_string(),
+          package_path: Some("java.lang".to_string()),
+        },
+        JavaBasicTypeResponse {
+          id: "java.lang.Integer".to_string(),
+          name: "Integer".to_string(),
+          package_path: Some("java.lang".to_string()),
+        },
+        JavaBasicTypeResponse {
+          id: "java.lang.Long".to_string(),
+          name: "Long".to_string(),
+          package_path: Some("java.lang".to_string()),
+        },
+        JavaBasicTypeResponse {
+          id: "java.lang.Boolean".to_string(),
+          name: "Boolean".to_string(),
+          package_path: Some("java.lang".to_string()),
+        },
+        JavaBasicTypeResponse {
+          id: "java.time.LocalDate".to_string(),
+          name: "LocalDate".to_string(),
+          package_path: Some("java.time".to_string()),
+        },
+        JavaBasicTypeResponse {
+          id: "java.time.LocalDateTime".to_string(),
+          name: "LocalDateTime".to_string(),
+          package_path: Some("java.time".to_string()),
+        },
+        JavaBasicTypeResponse {
+          id: "java.math.BigDecimal".to_string(),
+          name: "BigDecimal".to_string(),
+          package_path: Some("java.math".to_string()),
+        },
+      ],
+      types_with_length: vec!["java.lang.String".to_string()],
+      types_with_time_zone_storage: vec![],
+      types_with_temporal: vec![],
+      types_with_extra_other: vec!["java.lang.String".to_string()],
+      types_with_precision_and_scale: vec!["java.math.BigDecimal".to_string()],
+    }
+  }
+
+  /// Fetch type data from syntaxpresso-core
+  fn fetch_type_data() -> Result<TypeData, Box<dyn std::error::Error>> {
+    let mut type_data = TypeData {
+      all_types: vec![],
+      types_with_length: vec![],
+      types_with_time_zone_storage: vec![],
+      types_with_temporal: vec![],
+      types_with_extra_other: vec![],
+      types_with_precision_and_scale: vec![],
+    };
+
+    // Fetch all types
+    let response = get_java_basic_types_command::execute(&JavaBasicType::AllTypes);
+    if let Some(types) = response.data {
+      type_data.all_types = types;
+    }
+
+    // Fetch types with length
+    let response = get_java_basic_types_command::execute(&JavaBasicType::TypesWithLength);
+    if let Some(types) = response.data {
+      for type_obj in types {
+        type_data.types_with_length.push(type_obj.id);
+      }
+    }
+
+    // Fetch types with time zone storage
+    let response = get_java_basic_types_command::execute(&JavaBasicType::TypesWithTimeZoneStorage);
+    if let Some(types) = response.data {
+      for type_obj in types {
+        type_data.types_with_time_zone_storage.push(type_obj.id);
+      }
+    }
+
+    // Fetch types with temporal
+    let response = get_java_basic_types_command::execute(&JavaBasicType::TypesWithTemporal);
+    if let Some(types) = response.data {
+      for type_obj in types {
+        type_data.types_with_temporal.push(type_obj.id);
+      }
+    }
+
+    // Fetch types with extra other
+    let response = get_java_basic_types_command::execute(&JavaBasicType::TypesWithExtraOther);
+    if let Some(types) = response.data {
+      for type_obj in types {
+        type_data.types_with_extra_other.push(type_obj.id);
+      }
+    }
+
+    // Fetch types with precision and scale
+    let response =
+      get_java_basic_types_command::execute(&JavaBasicType::TypesWithPrecisionAndScale);
+    if let Some(types) = response.data {
+      for type_obj in types {
+        type_data.types_with_precision_and_scale.push(type_obj.id);
+      }
+    }
+
+    Ok(type_data)
+  }
+
+  /// Update field type and related visibility flags
+  fn update_field_type(&mut self) {
+    if let Some(idx) = self.field_type_state.selected() && let Some(type_info) = self.all_types.get(idx) {
+      self.field_type_index = idx;
+      self.field_type = type_info.name.clone();
+      self.field_package_path = type_info.package_path.clone();
+
+      // Update visibility based on type
+      let type_id = &type_info.id;
+
+        self.field_length_hidden = !self.types_with_length.contains(type_id);
+        self.field_time_zone_storage_hidden = !self.types_with_time_zone_storage.contains(type_id);
+      self.field_temporal_hidden = !self.types_with_temporal.contains(type_id);
+
+      if self.types_with_extra_other.contains(type_id) {
+        self.other_hidden = true;
+        self.other_extra_hidden = false;
+      } else {
+        self.other_hidden = false;
+        self.other_extra_hidden = true;
+      }
+
+      self.field_scale_hidden = !self.types_with_precision_and_scale.contains(type_id);
+      self.field_precision_hidden = !self.types_with_precision_and_scale.contains(type_id);
+    }
+  }
+
+  /// Move focus to the next visible field
+  fn focus_next(&mut self) {
+    // Reset back button confirmation when focus changes
+    self.back_pressed_once = false;
+
+    loop {
+      self.focused_field = match self.focused_field {
+        FocusedField::FieldType => FocusedField::FieldName,
+        FocusedField::FieldName => FocusedField::FieldLength,
+        FocusedField::FieldLength => FocusedField::TimeZoneStorage,
+        FocusedField::TimeZoneStorage => FocusedField::Temporal,
+        FocusedField::Temporal => FocusedField::PrecisionAndScale,
+        FocusedField::PrecisionAndScale => FocusedField::OtherOptions,
+        FocusedField::OtherOptions => FocusedField::BackButton,
+        FocusedField::BackButton => FocusedField::ConfirmButton,
+        FocusedField::ConfirmButton => FocusedField::FieldType,
+      };
+
+      // Skip hidden fields
+      if !self.is_field_hidden(self.focused_field) {
+        break;
+      }
+    }
+  }
+
+  /// Move focus to the previous visible field
+  fn focus_prev(&mut self) {
+    // Reset back button confirmation when focus changes
+    self.back_pressed_once = false;
+
+    loop {
+      self.focused_field = match self.focused_field {
+        FocusedField::FieldType => FocusedField::ConfirmButton,
+        FocusedField::FieldName => FocusedField::FieldType,
+        FocusedField::FieldLength => FocusedField::FieldName,
+        FocusedField::TimeZoneStorage => FocusedField::FieldLength,
+        FocusedField::Temporal => FocusedField::TimeZoneStorage,
+        FocusedField::PrecisionAndScale => FocusedField::Temporal,
+        FocusedField::OtherOptions => FocusedField::PrecisionAndScale,
+        FocusedField::BackButton => FocusedField::OtherOptions,
+        FocusedField::ConfirmButton => FocusedField::BackButton,
+      };
+
+      // Skip hidden fields
+      if !self.is_field_hidden(self.focused_field) {
+        break;
+      }
+    }
+  }
+
+  /// Check if a field is hidden
+  fn is_field_hidden(&self, field: FocusedField) -> bool {
+    match field {
+      FocusedField::FieldLength => self.field_length_hidden,
+      FocusedField::TimeZoneStorage => self.field_time_zone_storage_hidden,
+      FocusedField::Temporal => self.field_temporal_hidden,
+      FocusedField::PrecisionAndScale => self.field_scale_hidden && self.field_precision_hidden,
+      FocusedField::OtherOptions => self.other_hidden && self.other_extra_hidden,
+      _ => false,
+    }
+  }
+
+  /// Called when entering insert mode
+  fn on_enter_insert_mode(&mut self, key: KeyCode) {
+    if key == KeyCode::Char('a') {
+      match self.focused_field {
+        FocusedField::FieldName => {
+          self.field_name_cursor = self.field_name.len();
+        }
+        FocusedField::FieldLength => {
+          self.field_length_cursor = self.field_length.len();
+        }
+        _ => {}
+      }
+    }
+  }
+
+  /// Called when Enter is pressed in Normal mode
+  fn on_enter_pressed(&mut self) {
+    // In Normal mode, buttons should also work immediately
+    match self.focused_field {
+      FocusedField::ConfirmButton => {
+        self.execute_create_basic_field();
+      }
+      FocusedField::BackButton => {
+        if self.back_pressed_once {
+          self.should_go_back = true;
+        } else {
+          self.back_pressed_once = true;
+        }
+      }
+      _ => {}
+    }
+  }
+
+  /// Handle field-specific input in Insert mode
+  fn handle_field_insert(&mut self, key: KeyCode) {
+    match self.focused_field {
+      FocusedField::FieldType => self.handle_field_type_insert(key),
+      FocusedField::FieldName => self.handle_field_name_input(key),
+      FocusedField::FieldLength => self.handle_field_length_input(key),
+      FocusedField::TimeZoneStorage => self.handle_time_zone_storage_insert(key),
+      FocusedField::Temporal => self.handle_temporal_insert(key),
+      FocusedField::PrecisionAndScale => self.handle_precision_scale_input(key),
+      FocusedField::OtherOptions => self.handle_other_options_insert(key),
+      FocusedField::BackButton => {
+        // Back button requires double press for confirmation
+        if key == KeyCode::Enter {
+          if self.back_pressed_once {
+            self.should_go_back = true;
+          } else {
+            self.back_pressed_once = true;
+          }
+        }
+      }
+      FocusedField::ConfirmButton => {
+        // Confirm button acts immediately
+        if key == KeyCode::Enter {
+          self.execute_create_basic_field();
+        }
+      }
+    }
+  }
+
+  fn handle_field_type_insert(&mut self, key: KeyCode) {
+    match key {
+      KeyCode::Char('j') | KeyCode::Down => {
+        let len = self.all_types.len();
+        helpers::navigate_list_static(&KeyCode::Down, &mut self.field_type_state, len);
+        self.update_field_type();
+      }
+      KeyCode::Char('k') | KeyCode::Up => {
+        let len = self.all_types.len();
+        helpers::navigate_list_static(&KeyCode::Up, &mut self.field_type_state, len);
+        self.update_field_type();
+      }
+      KeyCode::Enter => {
+        self.state.input_mode = InputMode::Normal;
+      }
+      _ => {}
+    }
+  }
+
+  fn handle_field_name_input(&mut self, key: KeyCode) {
+    match key {
+      KeyCode::Char(c) => {
+        self.field_name.insert(self.field_name_cursor, c);
+        self.field_name_cursor += 1;
+      }
+      KeyCode::Backspace => {
+        if self.field_name_cursor > 0 {
+          self.field_name.remove(self.field_name_cursor - 1);
+          self.field_name_cursor -= 1;
+        }
+      }
+      KeyCode::Delete => {
+        if self.field_name_cursor < self.field_name.len() {
+          self.field_name.remove(self.field_name_cursor);
+        }
+      }
+      KeyCode::Left => {
+        if self.field_name_cursor > 0 {
+          self.field_name_cursor -= 1;
+        }
+      }
+      KeyCode::Right => {
+        if self.field_name_cursor < self.field_name.len() {
+          self.field_name_cursor += 1;
+        }
+      }
+      KeyCode::Home => {
+        self.field_name_cursor = 0;
+      }
+      KeyCode::End => {
+        self.field_name_cursor = self.field_name.len();
+      }
+      KeyCode::Enter => {
+        self.state.input_mode = InputMode::Normal;
+      }
+      _ => {}
+    }
+  }
+
+  fn handle_field_length_input(&mut self, key: KeyCode) {
+    match key {
+      KeyCode::Char(c) if c.is_ascii_digit() => {
+        self.field_length.insert(self.field_length_cursor, c);
+        self.field_length_cursor += 1;
+      }
+      KeyCode::Backspace => {
+        if self.field_length_cursor > 0 {
+          self.field_length.remove(self.field_length_cursor - 1);
+          self.field_length_cursor -= 1;
+        }
+      }
+      KeyCode::Delete => {
+        if self.field_length_cursor < self.field_length.len() {
+          self.field_length.remove(self.field_length_cursor);
+        }
+      }
+      KeyCode::Left => {
+        if self.field_length_cursor > 0 {
+          self.field_length_cursor -= 1;
+        }
+      }
+      KeyCode::Right => {
+        if self.field_length_cursor < self.field_length.len() {
+          self.field_length_cursor += 1;
+        }
+      }
+      KeyCode::Home => {
+        self.field_length_cursor = 0;
+      }
+      KeyCode::End => {
+        self.field_length_cursor = self.field_length.len();
+      }
+      KeyCode::Enter => {
+        self.state.input_mode = InputMode::Normal;
+      }
+      _ => {}
+    }
+  }
+
+  fn handle_time_zone_storage_insert(&mut self, key: KeyCode) {
+    match key {
+      KeyCode::Char('j') | KeyCode::Down => {
+        let variants = JavaFieldTimeZoneStorage::value_variants();
+        let len = variants.len();
+        helpers::navigate_list_static(&KeyCode::Down, &mut self.time_zone_storage_state, len);
+        self.time_zone_storage_index = self.time_zone_storage_state.selected();
+      }
+      KeyCode::Char('k') | KeyCode::Up => {
+        let variants = JavaFieldTimeZoneStorage::value_variants();
+        let len = variants.len();
+        helpers::navigate_list_static(&KeyCode::Up, &mut self.time_zone_storage_state, len);
+        self.time_zone_storage_index = self.time_zone_storage_state.selected();
+      }
+      KeyCode::Enter => {
+        self.state.input_mode = InputMode::Normal;
+      }
+      _ => {}
+    }
+  }
+
+  fn handle_temporal_insert(&mut self, key: KeyCode) {
+    match key {
+      KeyCode::Char('j') | KeyCode::Down => {
+        let variants = JavaFieldTemporal::value_variants();
+        let len = variants.len();
+        helpers::navigate_list_static(&KeyCode::Down, &mut self.temporal_state, len);
+        self.temporal_index = self.temporal_state.selected();
+      }
+      KeyCode::Char('k') | KeyCode::Up => {
+        let variants = JavaFieldTemporal::value_variants();
+        let len = variants.len();
+        helpers::navigate_list_static(&KeyCode::Up, &mut self.temporal_state, len);
+        self.temporal_index = self.temporal_state.selected();
+      }
+      KeyCode::Enter => {
+        self.state.input_mode = InputMode::Normal;
+      }
+      _ => {}
+    }
+  }
+
+  fn handle_precision_scale_input(&mut self, key: KeyCode) {
+    // For simplicity, we'll handle both precision and scale together
+    // In a more sophisticated implementation, you could track which one is focused
+    match key {
+      KeyCode::Char(c) if c.is_ascii_digit() => {
+        self.field_precision.insert(self.field_precision_cursor, c);
+        self.field_precision_cursor += 1;
+      }
+      KeyCode::Backspace => {
+        if self.field_precision_cursor > 0 {
+          self.field_precision.remove(self.field_precision_cursor - 1);
+          self.field_precision_cursor -= 1;
+        }
+      }
+      KeyCode::Tab => {
+        // Switch to scale input
+        self.field_scale_cursor = 0;
+      }
+      KeyCode::Enter => {
+        self.state.input_mode = InputMode::Normal;
+      }
+      _ => {}
+    }
+  }
+
+  fn handle_other_options_insert(&mut self, key: KeyCode) {
+    match key {
+      KeyCode::Char('j') | KeyCode::Down => {
+        let len = if !self.other_extra_hidden { 3 } else { 2 };
+        helpers::navigate_list_static(&KeyCode::Down, &mut self.other_options_state, len);
+      }
+      KeyCode::Char('k') | KeyCode::Up => {
+        let len = if !self.other_extra_hidden { 3 } else { 2 };
+        helpers::navigate_list_static(&KeyCode::Up, &mut self.other_options_state, len);
+      }
+      KeyCode::Char(' ') | KeyCode::Enter => {
+        // Toggle the selected option
+        if let Some(idx) = self.other_options_state.selected() {
+          if !self.other_extra_hidden {
+            match idx {
+              0 => self.large_object = !self.large_object,
+              1 => self.mandatory = !self.mandatory,
+              2 => self.unique = !self.unique,
+              _ => {}
+            }
+          } else {
+            match idx {
+              0 => self.mandatory = !self.mandatory,
+              1 => self.unique = !self.unique,
+              _ => {}
+            }
+          }
+        }
+        if key == KeyCode::Enter {
+          self.state.input_mode = InputMode::Normal;
+        }
+      }
+      _ => {}
+    }
+  }
+
+  fn execute_create_basic_field(&mut self) {
+    // Parse numeric fields
+    let field_length = self.field_length.parse::<u16>().ok();
+    let field_precision = self.field_precision.parse::<u16>().ok();
+    let field_scale = self.field_scale.parse::<u16>().ok();
+
+    // Get time zone storage
+    let field_timezone_storage = if !self.field_time_zone_storage_hidden {
+      self.time_zone_storage_index.and_then(|idx| {
+        let variants = JavaFieldTimeZoneStorage::value_variants();
+        variants.get(idx).cloned()
+      })
+    } else {
+      None
+    };
+
+    // Get temporal
+    let field_temporal = if !self.field_temporal_hidden {
+      self.temporal_index.and_then(|idx| {
+        let variants = JavaFieldTemporal::value_variants();
+        variants.get(idx).cloned()
+      })
+    } else {
+      None
+    };
+
+    // Build field config
+    let field_config = BasicFieldConfig {
+      field_name: self.field_name.clone(),
+      field_type: self.field_type.clone(),
+      field_type_package_name: self.field_package_path.clone(),
+      field_length,
+      field_precision,
+      field_scale,
+      field_temporal,
+      field_timezone_storage,
+      field_unique: self.unique,
+      field_nullable: !self.mandatory,
+      field_large_object: self.large_object,
+    };
+
+    // Call service
+    match create_jpa_entity_basic_field_service::run(
+      &self.entity_file_b64_src,
+      &self.entity_file_path,
+      &field_config,
+    ) {
+      Ok(response) => {
+        eprintln!(
+          "Successfully created field {} in {} at {}",
+          self.field_name, response.file_type, response.file_path
+        );
+        self.state.should_quit = true;
+        std::process::exit(0);
+      }
+      Err(e) => {
+        self.state.error_message = Some(format!("Error: {}", e));
+      }
+    }
+  }
+
+  fn render_field_type_selector(&mut self, frame: &mut Frame, area: Rect) {
+    let is_focused = self.focused_field == FocusedField::FieldType;
+
+    let items: Vec<ListItem> = if self.all_types.is_empty() {
+      // This shouldn't happen due to defaults, but just in case
+      vec![ListItem::new(" No types available")]
+    } else {
+      self
+        .all_types
+        .iter()
+        .enumerate()
+        .map(|(i, type_info)| {
+          let is_selected = self.field_type_state.selected() == Some(i);
+          let prefix = if is_selected { "●" } else { "○" };
+          let display =
+            format!("{} ({})", type_info.name, type_info.package_path.as_deref().unwrap_or(""));
+          ListItem::new(format!(" {} {}", prefix, display))
+        })
+        .collect()
+    };
+
+    let border_style =
+      if is_focused { Style::default().fg(Color::Yellow) } else { Style::default() };
+
+    let title = self.generate_title("Field type", is_focused);
+    let list = List::new(items)
+      .block(Block::default().title(title).borders(Borders::ALL).border_style(border_style))
+      .highlight_style(Style::default().bg(Color::DarkGray).add_modifier(Modifier::BOLD))
+      .highlight_symbol(">> ");
+
+    frame.render_stateful_widget(list, area, &mut self.field_type_state);
+  }
+
+  fn render_field_name_input(&mut self, frame: &mut Frame, area: Rect) {
+    let is_focused = self.focused_field == FocusedField::FieldName;
+    let border_style =
+      if is_focused { Style::default().fg(Color::Yellow) } else { Style::default() };
+    let title = self.generate_title("Field name", is_focused);
+    let input = Paragraph::new(self.field_name.as_str())
+      .block(Block::default().title(title).borders(Borders::ALL).border_style(border_style));
+    frame.render_widget(input, area);
+    if is_focused && self.state.input_mode == InputMode::Insert {
+      frame.set_cursor_position((area.x + self.field_name_cursor as u16 + 1, area.y + 1));
+    }
+  }
+
+  fn render_field_length_input(&mut self, frame: &mut Frame, area: Rect) {
+    if self.field_length_hidden {
+      return;
+    }
+
+    let is_focused = self.focused_field == FocusedField::FieldLength;
+    let border_style =
+      if is_focused { Style::default().fg(Color::Yellow) } else { Style::default() };
+    let title = self.generate_title("Field length", is_focused);
+    let input = Paragraph::new(self.field_length.as_str())
+      .block(Block::default().title(title).borders(Borders::ALL).border_style(border_style));
+    frame.render_widget(input, area);
+    if is_focused && self.state.input_mode == InputMode::Insert {
+      frame.set_cursor_position((area.x + self.field_length_cursor as u16 + 1, area.y + 1));
+    }
+  }
+
+  fn render_time_zone_storage_selector(&mut self, frame: &mut Frame, area: Rect) {
+    if self.field_time_zone_storage_hidden {
+      return;
+    }
+
+    let is_focused = self.focused_field == FocusedField::TimeZoneStorage;
+    let variants = JavaFieldTimeZoneStorage::value_variants();
+
+    let items: Vec<ListItem> = variants
+      .iter()
+      .enumerate()
+      .map(|(i, variant)| {
+        let is_selected = self.time_zone_storage_state.selected() == Some(i);
+        let prefix = if is_selected { "●" } else { "○" };
+        let display = variant.as_str();
+        ListItem::new(format!(" {} {}", prefix, display))
+      })
+      .collect();
+
+    let border_style =
+      if is_focused { Style::default().fg(Color::Yellow) } else { Style::default() };
+
+    let title = self.generate_title("Time Zone Storage", is_focused);
+    let list = List::new(items)
+      .block(Block::default().title(title).borders(Borders::ALL).border_style(border_style))
+      .highlight_style(Style::default().bg(Color::DarkGray).add_modifier(Modifier::BOLD))
+      .highlight_symbol(">> ");
+
+    frame.render_stateful_widget(list, area, &mut self.time_zone_storage_state);
+  }
+
+  fn render_temporal_selector(&mut self, frame: &mut Frame, area: Rect) {
+    if self.field_temporal_hidden {
+      return;
+    }
+
+    let is_focused = self.focused_field == FocusedField::Temporal;
+    let variants = JavaFieldTemporal::value_variants();
+
+    let items: Vec<ListItem> = variants
+      .iter()
+      .enumerate()
+      .map(|(i, variant)| {
+        let is_selected = self.temporal_state.selected() == Some(i);
+        let prefix = if is_selected { "●" } else { "○" };
+        let display = variant.as_str();
+        ListItem::new(format!(" {} {}", prefix, display))
+      })
+      .collect();
+
+    let border_style =
+      if is_focused { Style::default().fg(Color::Yellow) } else { Style::default() };
+
+    let title = self.generate_title("Temporal", is_focused);
+    let list = List::new(items)
+      .block(Block::default().title(title).borders(Borders::ALL).border_style(border_style))
+      .highlight_style(Style::default().bg(Color::DarkGray).add_modifier(Modifier::BOLD))
+      .highlight_symbol(">> ");
+
+    frame.render_stateful_widget(list, area, &mut self.temporal_state);
+  }
+
+  fn render_precision_scale_inputs(&mut self, frame: &mut Frame, area: Rect) {
+    if self.field_precision_hidden && self.field_scale_hidden {
+      return;
+    }
+
+    let is_focused = self.focused_field == FocusedField::PrecisionAndScale;
+
+    let chunks = Layout::default()
+      .direction(Direction::Horizontal)
+      .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+      .split(area);
+
+    if !self.field_precision_hidden {
+      let border_style =
+        if is_focused { Style::default().fg(Color::Yellow) } else { Style::default() };
+      let title = self.generate_title("Precision", is_focused);
+      let input = Paragraph::new(self.field_precision.as_str())
+        .block(Block::default().title(title).borders(Borders::ALL).border_style(border_style));
+      frame.render_widget(input, chunks[0]);
+    }
+
+    if !self.field_scale_hidden {
+      let border_style =
+        if is_focused { Style::default().fg(Color::Yellow) } else { Style::default() };
+      let input = Paragraph::new(self.field_scale.as_str())
+        .block(Block::default().title("Scale").borders(Borders::ALL).border_style(border_style));
+      frame.render_widget(input, chunks[1]);
+    }
+  }
+
+  fn render_other_options_selector(&mut self, frame: &mut Frame, area: Rect) {
+    if self.other_hidden && self.other_extra_hidden {
+      return;
+    }
+
+    let is_focused = self.focused_field == FocusedField::OtherOptions;
+
+    let mut items = Vec::new();
+
+    if !self.other_extra_hidden {
+      items.push(ListItem::new(format!(
+        " [{}] Large object",
+        if self.large_object { "x" } else { " " }
+      )));
+      items.push(ListItem::new(format!(" [{}] Mandatory", if self.mandatory { "x" } else { " " })));
+      items.push(ListItem::new(format!(" [{}] Unique", if self.unique { "x" } else { " " })));
+    } else {
+      items.push(ListItem::new(format!(" [{}] Mandatory", if self.mandatory { "x" } else { " " })));
+      items.push(ListItem::new(format!(" [{}] Unique", if self.unique { "x" } else { " " })));
+    }
+
+    let border_style =
+      if is_focused { Style::default().fg(Color::Yellow) } else { Style::default() };
+
+    let title = self.generate_title("Other options (Space to toggle)", is_focused);
+    let list = List::new(items)
+      .block(Block::default().title(title).borders(Borders::ALL).border_style(border_style))
+      .highlight_style(Style::default().bg(Color::DarkGray).add_modifier(Modifier::BOLD))
+      .highlight_symbol(">> ");
+
+    frame.render_stateful_widget(list, area, &mut self.other_options_state);
+  }
+
+  fn render_buttons(&self, frame: &mut Frame, area: Rect) {
+    // Split area into two columns for Back and Confirm buttons
+    let chunks = Layout::default()
+      .direction(Direction::Horizontal)
+      .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+      .split(area);
+
+    // Render Back button
+    let is_back_focused = self.focused_field == FocusedField::BackButton;
+    let back_color = if self.back_pressed_once { Color::Red } else { Color::Yellow };
+    let back_text = if self.back_pressed_once { "Press again to go back" } else { "Back" };
+    let back_style = if is_back_focused {
+      Style::default().bg(back_color).fg(Color::Black).add_modifier(Modifier::BOLD)
+    } else {
+      Style::default().fg(back_color)
+    };
+    let back_button = Paragraph::new(format!("[ {} ]", back_text))
+      .alignment(Alignment::Center)
+      .style(back_style)
+      .block(Block::default().borders(Borders::empty()));
+    frame.render_widget(back_button, chunks[0]);
+
+    // Render Confirm button
+    let is_confirm_focused = self.focused_field == FocusedField::ConfirmButton;
+    let color = match self.state.escape_handler.pressed_once {
+      true => Color::Red,
+      false => Color::Green,
+    };
+    let text = match self.state.escape_handler.pressed_once {
+      true => "Press esc again to close or any key to return",
+      false => "Confirm",
+    };
+    let confirm_style = if is_confirm_focused {
+      Style::default().bg(color).fg(Color::Black).add_modifier(Modifier::BOLD)
+    } else {
+      Style::default().fg(color)
+    };
+    let confirm_button = Paragraph::new(format!("[ {} ]", text))
+      .alignment(Alignment::Center)
+      .style(confirm_style)
+      .block(Block::default().borders(Borders::empty()));
+    frame.render_widget(confirm_button, chunks[1]);
+  }
+
+  fn render_title_bar(&self, frame: &mut Frame, area: Rect) {
+    let title_text = "Create new JPA Entity basic field";
+    let title = Paragraph::new(title_text)
+      .alignment(Alignment::Center)
+      .style(Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD))
+      .block(Block::default().borders(Borders::BOTTOM));
+    frame.render_widget(title, area);
+  }
+
+  pub fn render(&mut self, frame: &mut Frame) {
+    let area = frame.area();
+
+    // Calculate dynamic heights
+    // Ensure minimum height of 7 for the type list (5 items + 2 for borders)
+    let type_list_height = (self.all_types.len() as u16 + 2).clamp(7, 15);
+    let length_height = if self.field_length_hidden { 0 } else { 3 };
+    let tz_storage_height = if self.field_time_zone_storage_hidden { 0 } else { 7 };
+    let temporal_height = if self.field_temporal_hidden { 0 } else { 5 };
+    let precision_scale_height =
+      if self.field_precision_hidden && self.field_scale_hidden { 0 } else { 3 };
+    let other_height = if self.other_hidden && self.other_extra_hidden {
+      0
+    } else if !self.other_extra_hidden {
+      5
+    } else {
+      4
+    };
+
+    let mut constraints = vec![
+      Constraint::Length(2),                // Title bar
+      Constraint::Length(type_list_height), // Field type selector
+      Constraint::Length(3),                // Field name input
+    ];
+
+    if length_height > 0 {
+      constraints.push(Constraint::Length(length_height));
+    }
+    if tz_storage_height > 0 {
+      constraints.push(Constraint::Length(tz_storage_height));
+    }
+    if temporal_height > 0 {
+      constraints.push(Constraint::Length(temporal_height));
+    }
+    if precision_scale_height > 0 {
+      constraints.push(Constraint::Length(precision_scale_height));
+    }
+    if other_height > 0 {
+      constraints.push(Constraint::Length(other_height));
+    }
+
+    constraints.push(Constraint::Min(0)); // Flexible space for errors
+    constraints.push(Constraint::Length(1)); // Confirm button
+
+    let chunks =
+      Layout::default().direction(Direction::Vertical).constraints(constraints).split(area);
+
+    let mut chunk_idx = 0;
+
+    self.render_title_bar(frame, chunks[chunk_idx]);
+    chunk_idx += 1;
+
+    self.render_field_type_selector(frame, chunks[chunk_idx]);
+    chunk_idx += 1;
+
+    self.render_field_name_input(frame, chunks[chunk_idx]);
+    chunk_idx += 1;
+
+    if length_height > 0 {
+      self.render_field_length_input(frame, chunks[chunk_idx]);
+      chunk_idx += 1;
+    }
+
+    if tz_storage_height > 0 {
+      self.render_time_zone_storage_selector(frame, chunks[chunk_idx]);
+      chunk_idx += 1;
+    }
+
+    if temporal_height > 0 {
+      self.render_temporal_selector(frame, chunks[chunk_idx]);
+      chunk_idx += 1;
+    }
+
+    if precision_scale_height > 0 {
+      self.render_precision_scale_inputs(frame, chunks[chunk_idx]);
+      chunk_idx += 1;
+    }
+
+    if other_height > 0 {
+      self.render_other_options_selector(frame, chunks[chunk_idx]);
+      chunk_idx += 1;
+    }
+
+    // Render error message if present
+    if let Some(ref error_msg) = self.state.error_message {
+      let error_paragraph =
+        Paragraph::new(error_msg.as_str()).style(Style::default().fg(Color::Red)).block(
+          Block::default()
+            .title("Error")
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(Color::Red)),
+        );
+      frame.render_widget(error_paragraph, chunks[chunk_idx]);
+    }
+    chunk_idx += 1;
+
+    self.render_buttons(frame, chunks[chunk_idx]);
+  }
+
+  /// Check if user wants to go back to category selection
+  pub fn should_go_back(&self) -> bool {
+    self.should_go_back
+  }
+}
+
+// Implement the FormBehavior trait to get inherited methods
+impl FormBehavior for CreateBasicFieldForm {
+  fn form_state(&self) -> &FormState {
+    &self.state
+  }
+
+  fn form_state_mut(&mut self) -> &mut FormState {
+    &mut self.state
+  }
+
+  fn focus_next(&mut self) {
+    CreateBasicFieldForm::focus_next(self)
+  }
+
+  fn focus_prev(&mut self) {
+    CreateBasicFieldForm::focus_prev(self)
+  }
+
+  fn on_enter_insert_mode(&mut self, key: KeyCode) {
+    CreateBasicFieldForm::on_enter_insert_mode(self, key)
+  }
+
+  fn on_enter_pressed(&mut self) {
+    CreateBasicFieldForm::on_enter_pressed(self)
+  }
+
+  fn handle_field_insert(&mut self, key: KeyCode) {
+    CreateBasicFieldForm::handle_field_insert(self, key)
+  }
+
+  fn render(&mut self, frame: &mut Frame) {
+    CreateBasicFieldForm::render(self, frame)
+  }
+}
+
+// Helper struct for type data
+struct TypeData {
+  all_types: Vec<JavaBasicTypeResponse>,
+  types_with_length: Vec<String>,
+  types_with_time_zone_storage: Vec<String>,
+  types_with_temporal: Vec<String>,
+  types_with_extra_other: Vec<String>,
+  types_with_precision_and_scale: Vec<String>,
+}

--- a/src/ui/forms/create_entity_field.rs
+++ b/src/ui/forms/create_entity_field.rs
@@ -1,0 +1,473 @@
+use crossterm::event::KeyCode;
+use ratatui::{
+  Frame,
+  layout::{Alignment, Constraint, Direction, Layout},
+  style::{Color, Modifier, Style},
+  widgets::{Block, Borders, List, ListItem, ListState, Paragraph},
+};
+use std::path::PathBuf;
+
+use crate::ui::form_trait::{FormBehavior, FormState, InputMode, helpers};
+use crate::ui::forms::create_basic_field::CreateBasicFieldForm;
+use crate::ui::forms::create_enum_field::CreateEnumFieldForm;
+use crate::ui::forms::create_id_field::CreateIdFieldForm;
+
+/// Enum to hold different child form types
+enum ChildFormType {
+  Basic(Box<CreateBasicFieldForm>),
+  Enum(Box<CreateEnumFieldForm>),
+  Id(Box<CreateIdFieldForm>),
+}
+
+/// Field category options
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum FieldCategory {
+  Basic,
+  Enum,
+  Id,
+}
+
+impl FieldCategory {
+  fn all() -> Vec<FieldCategory> {
+    vec![FieldCategory::Basic, FieldCategory::Enum, FieldCategory::Id]
+  }
+
+  fn as_str(&self) -> &'static str {
+    match self {
+      FieldCategory::Basic => "Basic Field",
+      FieldCategory::Enum => "Enum Field",
+      FieldCategory::Id => "ID Field",
+    }
+  }
+}
+
+/// Represents which form state we're in
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum FormPhase {
+  CategorySelection,
+  ChildForm,
+}
+
+/// Focused field in category selection
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum FocusedField {
+  CategoryList,
+  NextButton,
+}
+
+/// Main form state for creating entity fields
+pub struct CreateEntityFieldForm {
+  // Common form state (embedded)
+  state: FormState,
+
+  // Current phase
+  phase: FormPhase,
+
+  // Category selection
+  selected_category: FieldCategory,
+  category_state: ListState,
+  focused_field: FocusedField,
+
+  // Integration with syntaxpresso-core
+  cwd: PathBuf,
+  entity_file_b64_src: String,
+  entity_file_path: PathBuf,
+
+  // Child form (if navigated to)
+  child_form: Option<ChildFormType>,
+}
+
+impl CreateEntityFieldForm {
+  pub fn new(cwd: PathBuf, entity_file_b64_src: String, entity_file_path: PathBuf) -> Self {
+    let mut category_state = ListState::default();
+    category_state.select(Some(0));
+
+    Self {
+      state: FormState::new(),
+      phase: FormPhase::CategorySelection,
+      selected_category: FieldCategory::Basic,
+      category_state,
+      focused_field: FocusedField::CategoryList,
+      cwd,
+      entity_file_b64_src,
+      entity_file_path,
+      child_form: None,
+    }
+  }
+
+  /// Update selected category from list state
+  fn update_selected_category(&mut self) {
+    if let Some(idx) = self.category_state.selected() {
+      let categories = FieldCategory::all();
+      if let Some(category) = categories.get(idx) {
+        self.selected_category = *category;
+      }
+    }
+  }
+
+  /// Navigate to child form based on selected category
+  fn navigate_to_child_form(&mut self) {
+    match self.selected_category {
+      FieldCategory::Basic => {
+        // Create basic field form
+        let basic_form = CreateBasicFieldForm::new(
+          self.cwd.clone(),
+          self.entity_file_b64_src.clone(),
+          self.entity_file_path.clone(),
+        );
+        self.child_form = Some(ChildFormType::Basic(Box::new(basic_form)));
+        self.phase = FormPhase::ChildForm;
+      }
+      FieldCategory::Enum => {
+        // Create enum field form
+        let enum_form = CreateEnumFieldForm::new(
+          self.cwd.clone(),
+          self.entity_file_b64_src.clone(),
+          self.entity_file_path.clone(),
+        );
+        self.child_form = Some(ChildFormType::Enum(Box::new(enum_form)));
+        self.phase = FormPhase::ChildForm;
+      }
+      FieldCategory::Id => {
+        // Create ID field form
+        let id_form = CreateIdFieldForm::new(
+          self.cwd.clone(),
+          self.entity_file_b64_src.clone(),
+          self.entity_file_path.clone(),
+        );
+        self.child_form = Some(ChildFormType::Id(Box::new(id_form)));
+        self.phase = FormPhase::ChildForm;
+      }
+    }
+  }
+
+  fn handle_category_selection_input(&mut self, key: KeyCode) {
+    match self.focused_field {
+      FocusedField::CategoryList => match key {
+        KeyCode::Char('j') | KeyCode::Down => {
+          let len = FieldCategory::all().len();
+          helpers::navigate_list_static(&KeyCode::Down, &mut self.category_state, len);
+          self.update_selected_category();
+        }
+        KeyCode::Char('k') | KeyCode::Up => {
+          let len = FieldCategory::all().len();
+          helpers::navigate_list_static(&KeyCode::Up, &mut self.category_state, len);
+          self.update_selected_category();
+        }
+        KeyCode::Enter => {
+          self.navigate_to_child_form();
+        }
+        _ => {}
+      },
+      FocusedField::NextButton => {
+        if let KeyCode::Enter = key {
+          self.navigate_to_child_form();
+        }
+      }
+    }
+  }
+
+  fn render_category_selection(&mut self, frame: &mut Frame) {
+    let area = frame.area();
+
+    let chunks = Layout::default()
+      .direction(Direction::Vertical)
+      .constraints([
+        Constraint::Length(2), // Title bar
+        Constraint::Length(7), // Category selector (3 items + 2 borders + padding)
+        Constraint::Min(0),    // Flexible space for errors
+        Constraint::Length(1), // Next button
+      ])
+      .split(area);
+
+    // Render title bar
+    let title = Paragraph::new("New Entity Field")
+      .alignment(Alignment::Center)
+      .style(Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD))
+      .block(Block::default().borders(Borders::BOTTOM));
+    frame.render_widget(title, chunks[0]);
+
+    // Render category selector
+    let is_focused = self.focused_field == FocusedField::CategoryList;
+    let categories = FieldCategory::all();
+    let items: Vec<ListItem> = categories
+      .iter()
+      .enumerate()
+      .map(|(i, category)| {
+        let is_selected = self.category_state.selected() == Some(i);
+        let prefix = if is_selected { "●" } else { "○" };
+        ListItem::new(format!(" {} {}", prefix, category.as_str()))
+      })
+      .collect();
+
+    let border_style =
+      if is_focused { Style::default().fg(Color::Yellow) } else { Style::default() };
+
+    let title = if is_focused && self.state.input_mode == InputMode::Insert {
+      "Category -- INSERT --"
+    } else if is_focused {
+      "Category -- NORMAL --"
+    } else {
+      "Category"
+    };
+
+    let list = List::new(items)
+      .block(Block::default().title(title).borders(Borders::ALL).border_style(border_style))
+      .highlight_style(Style::default().bg(Color::DarkGray).add_modifier(Modifier::BOLD))
+      .highlight_symbol(">> ");
+
+    frame.render_stateful_widget(list, chunks[1], &mut self.category_state);
+
+    // Render error message if present
+    if let Some(ref error_msg) = self.state.error_message {
+      let error_paragraph =
+        Paragraph::new(error_msg.as_str()).style(Style::default().fg(Color::Red)).block(
+          Block::default()
+            .title("Error")
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(Color::Red)),
+        );
+      frame.render_widget(error_paragraph, chunks[2]);
+    }
+
+    // Render next button
+    self.render_next_button(frame, chunks[3]);
+  }
+
+  fn render_next_button(&self, frame: &mut Frame, area: ratatui::layout::Rect) {
+    let is_focused = self.focused_field == FocusedField::NextButton;
+    let color = match self.state.escape_handler.pressed_once {
+      true => Color::Red,
+      false => Color::Green,
+    };
+    let text = match self.state.escape_handler.pressed_once {
+      true => "Press esc again to close or any key to return",
+      false => "Next",
+    };
+    let style = if is_focused {
+      Style::default().bg(color).fg(Color::Black).add_modifier(Modifier::BOLD)
+    } else {
+      Style::default().fg(color)
+    };
+    let button = Paragraph::new(format!("[ {} ]", text))
+      .alignment(Alignment::Center)
+      .style(style)
+      .block(Block::default().borders(Borders::empty()));
+    frame.render_widget(button, area);
+  }
+
+  fn render_child_form(&mut self, frame: &mut Frame) {
+    if let Some(ref mut child) = self.child_form {
+      match child {
+        ChildFormType::Basic(form) => form.render(frame),
+        ChildFormType::Enum(form) => form.render(frame),
+        ChildFormType::Id(form) => form.render(frame),
+      }
+    }
+  }
+}
+
+// Implement the FormBehavior trait
+impl FormBehavior for CreateEntityFieldForm {
+  fn form_state(&self) -> &FormState {
+    &self.state
+  }
+
+  fn form_state_mut(&mut self) -> &mut FormState {
+    &mut self.state
+  }
+
+  fn focus_next(&mut self) {
+    if self.phase == FormPhase::CategorySelection {
+      self.focused_field = match self.focused_field {
+        FocusedField::CategoryList => FocusedField::NextButton,
+        FocusedField::NextButton => FocusedField::CategoryList,
+      };
+    }
+    // Child forms handle their own focus
+  }
+
+  fn focus_prev(&mut self) {
+    if self.phase == FormPhase::CategorySelection {
+      self.focused_field = match self.focused_field {
+        FocusedField::CategoryList => FocusedField::NextButton,
+        FocusedField::NextButton => FocusedField::CategoryList,
+      };
+    }
+    // Child forms handle their own focus
+  }
+
+  fn on_enter_insert_mode(&mut self, _key: KeyCode) {
+    // Category selection doesn't use insert mode
+    // Child forms handle their own insert mode
+  }
+
+  fn on_enter_pressed(&mut self) {
+    match self.phase {
+      FormPhase::CategorySelection => {
+        if self.focused_field == FocusedField::NextButton {
+          self.navigate_to_child_form();
+        }
+      }
+      FormPhase::ChildForm => {
+        if let Some(ref mut child) = self.child_form {
+          match child {
+            ChildFormType::Basic(form) => form.on_enter_pressed(),
+            ChildFormType::Enum(form) => form.on_enter_pressed(),
+            ChildFormType::Id(form) => form.on_enter_pressed(),
+          }
+        }
+      }
+    }
+  }
+
+  fn handle_field_insert(&mut self, key: KeyCode) {
+    match self.phase {
+      FormPhase::CategorySelection => {
+        // Only category list can be in insert mode
+        if self.focused_field == FocusedField::CategoryList {
+          self.handle_category_selection_input(key);
+        }
+      }
+      FormPhase::ChildForm => {
+        if let Some(ref mut child) = self.child_form {
+          match child {
+            ChildFormType::Basic(form) => form.handle_field_insert(key),
+            ChildFormType::Enum(form) => form.handle_field_insert(key),
+            ChildFormType::Id(form) => form.handle_field_insert(key),
+          }
+        }
+      }
+    }
+  }
+
+  fn render(&mut self, frame: &mut Frame) {
+    match self.phase {
+      FormPhase::CategorySelection => self.render_category_selection(frame),
+      FormPhase::ChildForm => self.render_child_form(frame),
+    }
+  }
+
+  // Override handle_input to support proper escape handling
+  fn handle_input(&mut self, key: KeyCode) -> bool {
+    // Handle Ctrl+Enter (F1 signal) - navigate to child form from category selection
+    if key == KeyCode::F(1) {
+      match self.phase {
+        FormPhase::CategorySelection => {
+          self.navigate_to_child_form();
+          return false;
+        }
+        FormPhase::ChildForm => {
+          // Delegate to child
+          if let Some(ref mut child) = self.child_form {
+            let result = match child {
+              ChildFormType::Basic(form) => form.handle_input(key),
+              ChildFormType::Enum(form) => form.handle_input(key),
+              ChildFormType::Id(form) => form.handle_input(key),
+            };
+            return result;
+          }
+        }
+      }
+    }
+
+    // Handle Ctrl+Backspace (F2 signal) - not applicable for category selection (no back), delegate to child
+    if key == KeyCode::F(2) && self.phase == FormPhase::ChildForm && let Some(ref mut child) = self.child_form {
+      let result = match child {
+        ChildFormType::Basic(form) => form.handle_input(key),
+        ChildFormType::Enum(form) => form.handle_input(key),
+        ChildFormType::Id(form) => form.handle_input(key),
+      };
+      return result;
+    }
+
+    // Handle Esc key
+    if let KeyCode::Esc = key {
+      match self.phase {
+        FormPhase::ChildForm => {
+          // Delegate to child form for proper escape handling
+          if let Some(ref mut child) = self.child_form {
+            let result = match child {
+              ChildFormType::Basic(form) => form.handle_input(key),
+              ChildFormType::Enum(form) => form.handle_input(key),
+              ChildFormType::Id(form) => form.handle_input(key),
+            };
+            return result;
+          }
+        }
+        FormPhase::CategorySelection => {
+          // Normal Esc handling for category selection
+          let mode = self.input_mode();
+          let (should_quit, new_mode) = self.escape_handler_mut().handle_escape(mode);
+          self.set_input_mode(new_mode);
+          if should_quit {
+            return true;
+          }
+          return false;
+        }
+      }
+    }
+
+    // Handle C-c
+    if let KeyCode::Char('c') = key && self.input_mode() == InputMode::Insert {
+      self.set_input_mode(InputMode::Normal);
+      self.escape_handler_mut().reset();
+      return false;
+    }
+
+    // Reset escape handler on any other key
+    self.escape_handler_mut().reset();
+
+    // Dispatch to appropriate handler based on phase
+    if self.phase == FormPhase::ChildForm {
+      if let Some(ref mut child) = self.child_form {
+        // Handle input first
+        let quit = match child {
+          ChildFormType::Basic(form) => form.handle_input(key),
+          ChildFormType::Enum(form) => form.handle_input(key),
+          ChildFormType::Id(form) => form.handle_input(key),
+        };
+
+        if quit {
+          // Child signaled quit, propagate it
+          return true;
+        }
+
+        // Check if child wants to go back (after handling input)
+        let should_go_back = match child {
+          ChildFormType::Basic(form) => form.should_go_back(),
+          ChildFormType::Enum(form) => form.should_go_back(),
+          ChildFormType::Id(form) => form.should_go_back(),
+        };
+
+        if should_go_back {
+          // Go back to category selection
+          self.child_form = None;
+          self.phase = FormPhase::CategorySelection;
+          self.state.error_message = None;
+          self.escape_handler_mut().reset();
+          return false;
+        }
+
+        // Check if child form finished successfully
+        let child_should_quit = match child {
+          ChildFormType::Basic(form) => form.form_state().should_quit,
+          ChildFormType::Enum(form) => form.form_state().should_quit,
+          ChildFormType::Id(form) => form.form_state().should_quit,
+        };
+
+        if child_should_quit {
+          self.state.should_quit = true;
+          return true;
+        }
+      }
+    } else {
+      match self.input_mode() {
+        InputMode::Normal => self.handle_normal_mode(key),
+        InputMode::Insert => self.handle_field_insert(key),
+      }
+    }
+
+    false // Don't quit
+  }
+}

--- a/src/ui/forms/create_entity_field.rs
+++ b/src/ui/forms/create_entity_field.rs
@@ -372,7 +372,10 @@ impl FormBehavior for CreateEntityFieldForm {
     }
 
     // Handle Ctrl+Backspace (F2 signal) - not applicable for category selection (no back), delegate to child
-    if key == KeyCode::F(2) && self.phase == FormPhase::ChildForm && let Some(ref mut child) = self.child_form {
+    if key == KeyCode::F(2)
+      && self.phase == FormPhase::ChildForm
+      && let Some(ref mut child) = self.child_form
+    {
       let result = match child {
         ChildFormType::Basic(form) => form.handle_input(key),
         ChildFormType::Enum(form) => form.handle_input(key),
@@ -409,7 +412,9 @@ impl FormBehavior for CreateEntityFieldForm {
     }
 
     // Handle C-c
-    if let KeyCode::Char('c') = key && self.input_mode() == InputMode::Insert {
+    if let KeyCode::Char('c') = key
+      && self.input_mode() == InputMode::Insert
+    {
       self.set_input_mode(InputMode::Normal);
       self.escape_handler_mut().reset();
       return false;

--- a/src/ui/forms/create_entity_relationship.rs
+++ b/src/ui/forms/create_entity_relationship.rs
@@ -1,0 +1,474 @@
+use crossterm::event::KeyCode;
+use ratatui::{
+  Frame,
+  layout::{Alignment, Constraint, Direction, Layout},
+  style::{Color, Modifier, Style},
+  widgets::{Block, Borders, List, ListItem, ListState, Paragraph},
+};
+use std::path::{Path, PathBuf};
+
+use crate::commands::get_all_jpa_entities_command;
+use crate::ui::form_trait::{FormBehavior, FormState, InputMode, helpers};
+use crate::ui::forms::create_many_to_one_relationship::CreateManyToOneRelationshipForm;
+use crate::ui::forms::create_one_to_one_relationship::CreateOneToOneRelationshipForm;
+
+/// Enum to hold different child form types
+enum ChildFormType {
+  OneToOne(Box<CreateOneToOneRelationshipForm>),
+  ManyToOne(Box<CreateManyToOneRelationshipForm>),
+  // OneToMany(Box<CreateOneToManyRelationshipForm>), // Future
+  // ManyToMany(Box<CreateManyToManyRelationshipForm>), // Future
+}
+
+/// Relationship category options
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum RelationshipCategory {
+  OneToOne,
+  ManyToOne,
+  OneToMany,
+  ManyToMany,
+}
+
+impl RelationshipCategory {
+  fn all() -> Vec<RelationshipCategory> {
+    vec![
+      RelationshipCategory::OneToOne,
+      RelationshipCategory::ManyToOne,
+      RelationshipCategory::OneToMany,
+      RelationshipCategory::ManyToMany,
+    ]
+  }
+
+  fn as_str(&self) -> &'static str {
+    match self {
+      RelationshipCategory::OneToOne => "One-to-One",
+      RelationshipCategory::ManyToOne => "Many-to-One",
+      RelationshipCategory::OneToMany => "One-to-Many (Coming Soon)",
+      RelationshipCategory::ManyToMany => "Many-to-Many (Coming Soon)",
+    }
+  }
+
+  fn is_implemented(&self) -> bool {
+    matches!(self, RelationshipCategory::OneToOne | RelationshipCategory::ManyToOne)
+  }
+}
+
+/// Represents which form state we're in
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum FormPhase {
+  CategorySelection,
+  ChildForm,
+}
+
+/// Focused field in category selection
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum FocusedField {
+  CategoryList,
+  NextButton,
+}
+
+/// Main form state for creating entity relationships
+pub struct CreateEntityRelationshipForm {
+  // Common form state (embedded)
+  state: FormState,
+
+  // Current phase
+  phase: FormPhase,
+
+  // Category selection
+  selected_category: RelationshipCategory,
+  category_state: ListState,
+  focused_field: FocusedField,
+
+  // Integration with syntaxpresso-core
+  cwd: PathBuf,
+  entity_file_b64_src: String,
+  entity_file_path: PathBuf,
+
+  // Entity files for relationship selection
+  entity_files_json: String,
+
+  // Child form (if navigated to)
+  child_form: Option<ChildFormType>,
+}
+
+impl CreateEntityRelationshipForm {
+  pub fn new(cwd: PathBuf, entity_file_b64_src: String, entity_file_path: PathBuf) -> Self {
+    // Fetch entity files for relationships
+    let entity_files_json = Self::fetch_entity_files(&cwd).unwrap_or_else(|_| "[]".to_string());
+
+    let mut category_state = ListState::default();
+    category_state.select(Some(0));
+
+    Self {
+      state: FormState::new(),
+      phase: FormPhase::CategorySelection,
+      selected_category: RelationshipCategory::OneToOne,
+      category_state,
+      focused_field: FocusedField::CategoryList,
+      cwd,
+      entity_file_b64_src,
+      entity_file_path,
+      entity_files_json,
+      child_form: None,
+    }
+  }
+
+  fn fetch_entity_files(cwd: &Path) -> Result<String, Box<dyn std::error::Error>> {
+    let response = get_all_jpa_entities_command::execute(cwd);
+    let json = response.to_json_pretty()?;
+    Ok(json)
+  }
+
+  /// Update selected category from list state
+  fn update_selected_category(&mut self) {
+    if let Some(idx) = self.category_state.selected() {
+      let categories = RelationshipCategory::all();
+      if let Some(category) = categories.get(idx) {
+        self.selected_category = *category;
+      }
+    }
+  }
+
+  /// Navigate to child form based on selected category
+  fn navigate_to_child_form(&mut self) {
+    // Check if the selected category is implemented
+    if !self.selected_category.is_implemented() {
+      self.state.error_message =
+        Some(format!("{} is not yet implemented", self.selected_category.as_str()));
+      return;
+    }
+
+    match self.selected_category {
+      RelationshipCategory::OneToOne => {
+        let one_to_one_form = CreateOneToOneRelationshipForm::new(
+          self.cwd.clone(),
+          self.entity_file_b64_src.clone(),
+          self.entity_file_path.clone(),
+          self.entity_files_json.clone(),
+        );
+        self.child_form = Some(ChildFormType::OneToOne(Box::new(one_to_one_form)));
+        self.phase = FormPhase::ChildForm;
+
+        // Clear any previous error messages
+        self.state.error_message = None;
+      }
+      RelationshipCategory::ManyToOne => {
+        let many_to_one_form = CreateManyToOneRelationshipForm::new(
+          self.cwd.clone(),
+          self.entity_file_b64_src.clone(),
+          self.entity_file_path.clone(),
+          self.entity_files_json.clone(),
+        );
+        self.child_form = Some(ChildFormType::ManyToOne(Box::new(many_to_one_form)));
+        self.phase = FormPhase::ChildForm;
+        self.state.error_message = None;
+      }
+      _ => {
+        self.state.error_message =
+          Some(format!("{} is not yet implemented", self.selected_category.as_str()));
+      }
+    }
+  }
+
+  fn handle_category_selection_input(&mut self, key: KeyCode) {
+    match self.focused_field {
+      FocusedField::CategoryList => match key {
+        KeyCode::Char('j') | KeyCode::Down => {
+          let len = RelationshipCategory::all().len();
+          helpers::navigate_list_static(&KeyCode::Down, &mut self.category_state, len);
+          self.update_selected_category();
+        }
+        KeyCode::Char('k') | KeyCode::Up => {
+          let len = RelationshipCategory::all().len();
+          helpers::navigate_list_static(&KeyCode::Up, &mut self.category_state, len);
+          self.update_selected_category();
+        }
+        KeyCode::Enter => {
+          self.state.input_mode = InputMode::Normal;
+        }
+        _ => {}
+      },
+      FocusedField::NextButton => {
+        if let KeyCode::Enter = key {
+          self.navigate_to_child_form();
+        }
+      }
+    }
+  }
+
+  fn render_category_selection(&mut self, frame: &mut Frame) {
+    let area = frame.area();
+
+    let chunks = Layout::default()
+      .direction(Direction::Vertical)
+      .constraints([
+        Constraint::Length(2), // Title bar
+        Constraint::Length(8), // Category selector
+        Constraint::Min(0),    // Flexible space for errors
+        Constraint::Length(1), // Next button
+      ])
+      .split(area);
+
+    // Render title bar
+    let title = Paragraph::new("New Entity Relationship")
+      .alignment(Alignment::Center)
+      .style(Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD))
+      .block(Block::default().borders(Borders::BOTTOM));
+    frame.render_widget(title, chunks[0]);
+
+    // Render category selector
+    let is_focused = self.focused_field == FocusedField::CategoryList;
+    let categories = RelationshipCategory::all();
+    let items: Vec<ListItem> = categories
+      .iter()
+      .enumerate()
+      .map(|(i, category)| {
+        let is_selected = self.category_state.selected() == Some(i);
+        let prefix = if is_selected { "●" } else { "○" };
+        ListItem::new(format!(" {} {}", prefix, category.as_str()))
+      })
+      .collect();
+
+    let border_style =
+      if is_focused { Style::default().fg(Color::Yellow) } else { Style::default() };
+
+    let title = self.generate_title("Relationship Type", is_focused);
+    let list = List::new(items)
+      .block(Block::default().title(title).borders(Borders::ALL).border_style(border_style))
+      .highlight_style(Style::default().bg(Color::DarkGray).add_modifier(Modifier::BOLD))
+      .highlight_symbol(">> ");
+
+    frame.render_stateful_widget(list, chunks[1], &mut self.category_state);
+
+    // Render error message if present
+    if let Some(ref error_msg) = self.state.error_message {
+      let error_paragraph =
+        Paragraph::new(error_msg.as_str()).style(Style::default().fg(Color::Red)).block(
+          Block::default()
+            .title("Error")
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(Color::Red)),
+        );
+      frame.render_widget(error_paragraph, chunks[2]);
+    }
+
+    // Render next button
+    self.render_next_button(frame, chunks[3]);
+  }
+
+  fn render_next_button(&self, frame: &mut Frame, area: ratatui::layout::Rect) {
+    let is_focused = self.focused_field == FocusedField::NextButton;
+    let color = match self.state.escape_handler.pressed_once {
+      true => Color::Red,
+      false => Color::Green,
+    };
+    let text = match self.state.escape_handler.pressed_once {
+      true => "Press esc again to close or any key to return",
+      false => "Next",
+    };
+    let style = if is_focused {
+      Style::default().bg(color).fg(Color::Black).add_modifier(Modifier::BOLD)
+    } else {
+      Style::default().fg(color)
+    };
+    let button = Paragraph::new(format!("[ {} ]", text))
+      .alignment(Alignment::Center)
+      .style(style)
+      .block(Block::default().borders(Borders::empty()));
+    frame.render_widget(button, area);
+  }
+
+  fn render_child_form(&mut self, frame: &mut Frame) {
+    if let Some(ref mut child) = self.child_form {
+      match child {
+        ChildFormType::OneToOne(form) => form.render(frame),
+        ChildFormType::ManyToOne(form) => form.render(frame),
+      }
+    }
+  }
+}
+
+// Implement the FormBehavior trait
+impl FormBehavior for CreateEntityRelationshipForm {
+  fn form_state(&self) -> &FormState {
+    &self.state
+  }
+
+  fn form_state_mut(&mut self) -> &mut FormState {
+    &mut self.state
+  }
+
+  fn focus_next(&mut self) {
+    if self.phase == FormPhase::CategorySelection {
+      self.focused_field = match self.focused_field {
+        FocusedField::CategoryList => FocusedField::NextButton,
+        FocusedField::NextButton => FocusedField::CategoryList,
+      };
+    }
+  }
+
+  fn focus_prev(&mut self) {
+    if self.phase == FormPhase::CategorySelection {
+      self.focused_field = match self.focused_field {
+        FocusedField::CategoryList => FocusedField::NextButton,
+        FocusedField::NextButton => FocusedField::CategoryList,
+      };
+    }
+  }
+
+  fn on_enter_insert_mode(&mut self, _key: KeyCode) {
+    // No special behavior needed for category selection
+  }
+
+  fn on_enter_pressed(&mut self) {
+    match self.phase {
+      FormPhase::CategorySelection => {
+        if self.focused_field == FocusedField::NextButton {
+          self.navigate_to_child_form();
+        }
+      }
+      FormPhase::ChildForm => {
+        if let Some(ref mut child) = self.child_form {
+          match child {
+            ChildFormType::OneToOne(form) => form.on_enter_pressed(),
+            ChildFormType::ManyToOne(form) => form.on_enter_pressed(),
+          }
+        }
+      }
+    }
+  }
+
+  fn handle_field_insert(&mut self, key: KeyCode) {
+    match self.phase {
+      FormPhase::CategorySelection => {
+        if self.focused_field == FocusedField::CategoryList {
+          self.handle_category_selection_input(key);
+        }
+      }
+      FormPhase::ChildForm => {
+        if let Some(ref mut child) = self.child_form {
+          match child {
+            ChildFormType::OneToOne(form) => form.handle_field_insert(key),
+            ChildFormType::ManyToOne(form) => form.handle_field_insert(key),
+          }
+        }
+      }
+    }
+  }
+
+  fn render(&mut self, frame: &mut Frame) {
+    match self.phase {
+      FormPhase::CategorySelection => self.render_category_selection(frame),
+      FormPhase::ChildForm => self.render_child_form(frame),
+    }
+  }
+
+  // Override handle_input to support proper escape handling and child forms
+  fn handle_input(&mut self, key: KeyCode) -> bool {
+    // Handle Ctrl+Enter (F1 signal)
+    if key == KeyCode::F(1) {
+      match self.phase {
+        FormPhase::CategorySelection => {
+          self.navigate_to_child_form();
+          return false;
+        }
+        FormPhase::ChildForm => {
+          if let Some(ref mut child) = self.child_form {
+            return match child {
+              ChildFormType::OneToOne(form) => form.handle_input(key),
+              ChildFormType::ManyToOne(form) => form.handle_input(key),
+            };
+          }
+        }
+      }
+    }
+
+    // Handle Ctrl+Backspace (F2 signal)
+    if key == KeyCode::F(2) && self.phase == FormPhase::ChildForm && let Some(ref mut child) = self.child_form {
+      return match child {
+        ChildFormType::OneToOne(form) => form.handle_input(key),
+        ChildFormType::ManyToOne(form) => form.handle_input(key),
+      };
+    }
+
+    // Handle Esc key
+    if let KeyCode::Esc = key {
+      match self.phase {
+        FormPhase::ChildForm => {
+          if let Some(ref mut child) = self.child_form {
+            return match child {
+              ChildFormType::OneToOne(form) => form.handle_input(key),
+              ChildFormType::ManyToOne(form) => form.handle_input(key),
+            };
+          }
+        }
+        FormPhase::CategorySelection => {
+          let mode = self.input_mode();
+          let (should_quit, new_mode) = self.escape_handler_mut().handle_escape(mode);
+          self.set_input_mode(new_mode);
+          if should_quit {
+            return true;
+          }
+          return false;
+        }
+      }
+    }
+
+    // Handle C-c
+    if let KeyCode::Char('c') = key && self.input_mode() == InputMode::Insert {
+      self.set_input_mode(InputMode::Normal);
+      self.escape_handler_mut().reset();
+      return false;
+    }
+
+    // Reset escape handler on any other key
+    self.escape_handler_mut().reset();
+
+    // Dispatch to appropriate handler based on phase
+    if self.phase == FormPhase::ChildForm {
+      if let Some(ref mut child) = self.child_form {
+        let quit = match child {
+          ChildFormType::OneToOne(form) => form.handle_input(key),
+          ChildFormType::ManyToOne(form) => form.handle_input(key),
+        };
+
+        if quit {
+          return true;
+        }
+
+        // Check if child wants to go back
+        let should_go_back = match child {
+          ChildFormType::OneToOne(form) => form.should_go_back(),
+          ChildFormType::ManyToOne(form) => form.should_go_back(),
+        };
+
+        if should_go_back {
+          self.child_form = None;
+          self.phase = FormPhase::CategorySelection;
+          self.state.error_message = None;
+          self.escape_handler_mut().reset();
+          return false;
+        }
+
+        // Check if child form finished successfully
+        let child_should_quit = match child {
+          ChildFormType::OneToOne(form) => form.form_state().should_quit,
+          ChildFormType::ManyToOne(form) => form.form_state().should_quit,
+        };
+
+        if child_should_quit {
+          self.state.should_quit = true;
+          return true;
+        }
+      }
+    } else {
+      match self.input_mode() {
+        InputMode::Normal => self.handle_normal_mode(key),
+        InputMode::Insert => self.handle_field_insert(key),
+      }
+    }
+
+    false
+  }
+}

--- a/src/ui/forms/create_entity_relationship.rs
+++ b/src/ui/forms/create_entity_relationship.rs
@@ -385,7 +385,10 @@ impl FormBehavior for CreateEntityRelationshipForm {
     }
 
     // Handle Ctrl+Backspace (F2 signal)
-    if key == KeyCode::F(2) && self.phase == FormPhase::ChildForm && let Some(ref mut child) = self.child_form {
+    if key == KeyCode::F(2)
+      && self.phase == FormPhase::ChildForm
+      && let Some(ref mut child) = self.child_form
+    {
       return match child {
         ChildFormType::OneToOne(form) => form.handle_input(key),
         ChildFormType::ManyToOne(form) => form.handle_input(key),
@@ -416,7 +419,9 @@ impl FormBehavior for CreateEntityRelationshipForm {
     }
 
     // Handle C-c
-    if let KeyCode::Char('c') = key && self.input_mode() == InputMode::Insert {
+    if let KeyCode::Char('c') = key
+      && self.input_mode() == InputMode::Insert
+    {
       self.set_input_mode(InputMode::Normal);
       self.escape_handler_mut().reset();
       return false;

--- a/src/ui/forms/create_enum_field.rs
+++ b/src/ui/forms/create_enum_field.rs
@@ -1,0 +1,793 @@
+#![allow(dead_code)]
+
+use crossterm::event::KeyCode;
+use ratatui::{
+  Frame,
+  layout::{Alignment, Constraint, Direction, Layout, Rect},
+  style::{Color, Modifier, Style},
+  widgets::{Block, Borders, List, ListItem, ListState, Paragraph},
+};
+use std::path::{Path, PathBuf};
+
+use crate::commands::get_java_files_command;
+use crate::commands::services::create_jpa_entity_enum_field_service;
+use crate::common::types::enum_field_config::EnumFieldConfig;
+use crate::common::types::java_enum_type::JavaEnumType;
+use crate::common::types::java_file_type::JavaFileType;
+use crate::ui::form_trait::{FormBehavior, FormState, InputMode, helpers};
+
+/// Represents which field is currently focused
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum FocusedField {
+  EnumType,
+  EnumTypeStorage,
+  FieldName,
+  FieldLength,
+  OtherOptions,
+  BackButton,
+  ConfirmButton,
+}
+
+/// Represents an enum file response
+#[derive(Debug, Clone, serde::Deserialize)]
+struct EnumFileResponse {
+  #[serde(rename = "fileType")]
+  file_type: String,
+  #[serde(rename = "filePackageName")]
+  file_package_name: String,
+  #[serde(rename = "filePath")]
+  file_path: String,
+}
+
+/// Main form state for creating an enum field
+pub struct CreateEnumFieldForm {
+  // Common form state (embedded)
+  state: FormState,
+
+  // Field values
+  enum_type_index: usize,
+  enum_package_name: String,
+  enum_type: String,
+  enum_type_path: String,
+  field_name: String,
+  enum_type_storage_index: usize,
+  field_length: String,
+
+  // Other options (checkboxes)
+  mandatory: bool,
+  unique: bool,
+
+  // Enum lists
+  all_enum_types: Vec<EnumFileResponse>,
+
+  // List states
+  enum_type_state: ListState,
+  enum_type_storage_state: ListState,
+  other_options_state: ListState,
+
+  // Text input states
+  field_name_cursor: usize,
+  field_length_cursor: usize,
+
+  // Visibility flags
+  field_length_hidden: bool,
+
+  // Focus management
+  focused_field: FocusedField,
+
+  // Integration with syntaxpresso-core
+  cwd: PathBuf,
+  entity_file_b64_src: String,
+  entity_file_path: PathBuf,
+
+  // Navigation
+  should_go_back: bool,
+  back_pressed_once: bool,
+}
+
+impl CreateEnumFieldForm {
+  pub fn new(cwd: PathBuf, entity_file_b64_src: String, entity_file_path: PathBuf) -> Self {
+    // Fetch all enum types from syntaxpresso-core
+    let all_enum_types = Self::fetch_enum_types(&cwd).unwrap_or_default();
+
+    let mut enum_type_state = ListState::default();
+    enum_type_state.select(Some(0));
+
+    let mut enum_type_storage_state = ListState::default();
+    enum_type_storage_state.select(Some(1)); // Default to STRING
+
+    let mut other_options_state = ListState::default();
+    other_options_state.select(Some(0));
+
+    // Default values
+    let (default_enum_package, default_enum_type, default_enum_path) = if !all_enum_types.is_empty()
+    {
+      (
+        all_enum_types[0].file_package_name.clone(),
+        all_enum_types[0].file_type.clone(),
+        all_enum_types[0].file_path.clone(),
+      )
+    } else {
+      (String::new(), String::new(), String::new())
+    };
+
+    let default_field_name = Self::auto_field_name(&default_enum_type);
+
+    Self {
+      state: FormState::new(),
+      enum_type_index: 0,
+      enum_package_name: default_enum_package,
+      enum_type: default_enum_type,
+      enum_type_path: default_enum_path,
+      field_name: default_field_name,
+      enum_type_storage_index: 1, // STRING (index 1)
+      field_length: "255".to_string(),
+      mandatory: false,
+      unique: false,
+      all_enum_types,
+      enum_type_state,
+      enum_type_storage_state,
+      other_options_state,
+      field_name_cursor: 0,
+      field_length_cursor: 3,
+      field_length_hidden: false, // STRING type shows length by default
+      focused_field: FocusedField::EnumType,
+      cwd,
+      entity_file_b64_src,
+      entity_file_path,
+      should_go_back: false,
+      back_pressed_once: false,
+    }
+  }
+
+  /// Fetch enum types from syntaxpresso-core
+  fn fetch_enum_types(cwd: &Path) -> Result<Vec<EnumFileResponse>, Box<dyn std::error::Error>> {
+    let response = get_java_files_command::execute(cwd, &JavaFileType::Enum);
+
+    let mut enum_types = Vec::new();
+    if let Some(data) = response.data {
+      for file in data.files {
+        enum_types.push(EnumFileResponse {
+          file_type: file.file_type,
+          file_package_name: file.file_package_name,
+          file_path: file.file_path,
+        });
+      }
+    }
+
+    Ok(enum_types)
+  }
+
+  /// Auto-generate field name from enum type (CamelCase -> camelCase)
+  fn auto_field_name(type_name: &str) -> String {
+    if type_name.is_empty() {
+      return String::new();
+    }
+    let first_char = type_name.chars().next().unwrap();
+    format!("{}{}", first_char.to_lowercase(), &type_name[1..])
+  }
+
+  /// Update enum type and related values
+  fn update_enum_type(&mut self) {
+    if let Some(idx) = self.enum_type_state.selected() && let Some(enum_info) = self.all_enum_types.get(idx) {
+      self.enum_type_index = idx;
+      self.enum_type = enum_info.file_type.clone();
+      self.enum_package_name = enum_info.file_package_name.clone();
+      self.enum_type_path = enum_info.file_path.clone();
+      self.field_name = Self::auto_field_name(&self.enum_type);
+      self.field_name_cursor = self.field_name.len();
+    }
+  }
+
+  /// Update enum type storage and related visibility
+  fn update_enum_type_storage(&mut self) {
+    if let Some(idx) = self.enum_type_storage_state.selected() {
+      self.enum_type_storage_index = idx;
+      // STRING (index 1) shows length field, ORDINAL (index 0) hides it
+      self.field_length_hidden = idx == 0;
+    }
+  }
+
+  /// Move focus to the next visible field
+  fn focus_next(&mut self) {
+    // Reset back button confirmation when focus changes
+    self.back_pressed_once = false;
+
+    loop {
+      self.focused_field = match self.focused_field {
+        FocusedField::EnumType => FocusedField::EnumTypeStorage,
+        FocusedField::EnumTypeStorage => FocusedField::FieldName,
+        FocusedField::FieldName => FocusedField::FieldLength,
+        FocusedField::FieldLength => FocusedField::OtherOptions,
+        FocusedField::OtherOptions => FocusedField::BackButton,
+        FocusedField::BackButton => FocusedField::ConfirmButton,
+        FocusedField::ConfirmButton => FocusedField::EnumType,
+      };
+
+      // Skip hidden fields
+      if !self.is_field_hidden(self.focused_field) {
+        break;
+      }
+    }
+  }
+
+  /// Move focus to the previous visible field
+  fn focus_prev(&mut self) {
+    // Reset back button confirmation when focus changes
+    self.back_pressed_once = false;
+
+    loop {
+      self.focused_field = match self.focused_field {
+        FocusedField::EnumType => FocusedField::ConfirmButton,
+        FocusedField::EnumTypeStorage => FocusedField::EnumType,
+        FocusedField::FieldName => FocusedField::EnumTypeStorage,
+        FocusedField::FieldLength => FocusedField::FieldName,
+        FocusedField::OtherOptions => FocusedField::FieldLength,
+        FocusedField::BackButton => FocusedField::OtherOptions,
+        FocusedField::ConfirmButton => FocusedField::BackButton,
+      };
+
+      // Skip hidden fields
+      if !self.is_field_hidden(self.focused_field) {
+        break;
+      }
+    }
+  }
+
+  /// Check if a field is hidden
+  fn is_field_hidden(&self, field: FocusedField) -> bool {
+    match field {
+      FocusedField::FieldLength => self.field_length_hidden,
+      _ => false,
+    }
+  }
+
+  /// Called when entering insert mode
+  fn on_enter_insert_mode(&mut self, key: KeyCode) {
+    if key == KeyCode::Char('a') {
+      match self.focused_field {
+        FocusedField::FieldName => {
+          self.field_name_cursor = self.field_name.len();
+        }
+        FocusedField::FieldLength => {
+          self.field_length_cursor = self.field_length.len();
+        }
+        _ => {}
+      }
+    }
+  }
+
+  /// Called when Enter is pressed in Normal mode
+  fn on_enter_pressed(&mut self) {
+    match self.focused_field {
+      FocusedField::ConfirmButton => {
+        self.execute_create_enum_field();
+      }
+      FocusedField::BackButton => {
+        if self.back_pressed_once {
+          self.should_go_back = true;
+        } else {
+          self.back_pressed_once = true;
+        }
+      }
+      _ => {}
+    }
+  }
+
+  /// Handle field-specific input in Insert mode
+  fn handle_field_insert(&mut self, key: KeyCode) {
+    match self.focused_field {
+      FocusedField::EnumType => self.handle_enum_type_insert(key),
+      FocusedField::EnumTypeStorage => self.handle_enum_type_storage_insert(key),
+      FocusedField::FieldName => self.handle_field_name_input(key),
+      FocusedField::FieldLength => self.handle_field_length_input(key),
+      FocusedField::OtherOptions => self.handle_other_options_insert(key),
+      FocusedField::BackButton => {
+        if key == KeyCode::Enter {
+          if self.back_pressed_once {
+            self.should_go_back = true;
+          } else {
+            self.back_pressed_once = true;
+          }
+        }
+      }
+      FocusedField::ConfirmButton => {
+        if key == KeyCode::Enter {
+          self.execute_create_enum_field();
+        }
+      }
+    }
+  }
+
+  fn handle_enum_type_insert(&mut self, key: KeyCode) {
+    match key {
+      KeyCode::Char('j') | KeyCode::Down => {
+        let len = self.all_enum_types.len();
+        helpers::navigate_list_static(&KeyCode::Down, &mut self.enum_type_state, len);
+        self.update_enum_type();
+      }
+      KeyCode::Char('k') | KeyCode::Up => {
+        let len = self.all_enum_types.len();
+        helpers::navigate_list_static(&KeyCode::Up, &mut self.enum_type_state, len);
+        self.update_enum_type();
+      }
+      KeyCode::Enter => {
+        self.state.input_mode = InputMode::Normal;
+      }
+      _ => {}
+    }
+  }
+
+  fn handle_enum_type_storage_insert(&mut self, key: KeyCode) {
+    match key {
+      KeyCode::Char('j') | KeyCode::Down => {
+        // JavaEnumType has 2 variants: Ordinal (0) and String (1)
+        helpers::navigate_list_static(&KeyCode::Down, &mut self.enum_type_storage_state, 2);
+        self.update_enum_type_storage();
+      }
+      KeyCode::Char('k') | KeyCode::Up => {
+        // JavaEnumType has 2 variants: Ordinal (0) and String (1)
+        helpers::navigate_list_static(&KeyCode::Up, &mut self.enum_type_storage_state, 2);
+        self.update_enum_type_storage();
+      }
+      KeyCode::Enter => {
+        self.state.input_mode = InputMode::Normal;
+      }
+      _ => {}
+    }
+  }
+
+  fn handle_field_name_input(&mut self, key: KeyCode) {
+    match key {
+      KeyCode::Char(c) => {
+        self.field_name.insert(self.field_name_cursor, c);
+        self.field_name_cursor += 1;
+      }
+      KeyCode::Backspace => {
+        if self.field_name_cursor > 0 {
+          self.field_name.remove(self.field_name_cursor - 1);
+          self.field_name_cursor -= 1;
+        }
+      }
+      KeyCode::Delete => {
+        if self.field_name_cursor < self.field_name.len() {
+          self.field_name.remove(self.field_name_cursor);
+        }
+      }
+      KeyCode::Left => {
+        if self.field_name_cursor > 0 {
+          self.field_name_cursor -= 1;
+        }
+      }
+      KeyCode::Right => {
+        if self.field_name_cursor < self.field_name.len() {
+          self.field_name_cursor += 1;
+        }
+      }
+      KeyCode::Home => {
+        self.field_name_cursor = 0;
+      }
+      KeyCode::End => {
+        self.field_name_cursor = self.field_name.len();
+      }
+      KeyCode::Enter => {
+        self.state.input_mode = InputMode::Normal;
+      }
+      _ => {}
+    }
+  }
+
+  fn handle_field_length_input(&mut self, key: KeyCode) {
+    match key {
+      KeyCode::Char(c) if c.is_ascii_digit() => {
+        self.field_length.insert(self.field_length_cursor, c);
+        self.field_length_cursor += 1;
+      }
+      KeyCode::Backspace => {
+        if self.field_length_cursor > 0 {
+          self.field_length.remove(self.field_length_cursor - 1);
+          self.field_length_cursor -= 1;
+        }
+      }
+      KeyCode::Delete => {
+        if self.field_length_cursor < self.field_length.len() {
+          self.field_length.remove(self.field_length_cursor);
+        }
+      }
+      KeyCode::Left => {
+        if self.field_length_cursor > 0 {
+          self.field_length_cursor -= 1;
+        }
+      }
+      KeyCode::Right => {
+        if self.field_length_cursor < self.field_length.len() {
+          self.field_length_cursor += 1;
+        }
+      }
+      KeyCode::Home => {
+        self.field_length_cursor = 0;
+      }
+      KeyCode::End => {
+        self.field_length_cursor = self.field_length.len();
+      }
+      KeyCode::Enter => {
+        self.state.input_mode = InputMode::Normal;
+      }
+      _ => {}
+    }
+  }
+
+  fn handle_other_options_insert(&mut self, key: KeyCode) {
+    match key {
+      KeyCode::Char('j') | KeyCode::Down => {
+        helpers::navigate_list_static(&KeyCode::Down, &mut self.other_options_state, 2);
+      }
+      KeyCode::Char('k') | KeyCode::Up => {
+        helpers::navigate_list_static(&KeyCode::Up, &mut self.other_options_state, 2);
+      }
+      KeyCode::Char(' ') | KeyCode::Enter => {
+        if let Some(idx) = self.other_options_state.selected() {
+          match idx {
+            0 => self.mandatory = !self.mandatory,
+            1 => self.unique = !self.unique,
+            _ => {}
+          }
+        }
+        if key == KeyCode::Enter {
+          self.state.input_mode = InputMode::Normal;
+        }
+      }
+      _ => {}
+    }
+  }
+
+  fn execute_create_enum_field(&mut self) {
+    // Validate field name
+    if self.field_name.is_empty() {
+      self.state.error_message = Some("Field name cannot be empty".to_string());
+      return;
+    }
+
+    // Validate enum type selected
+    if self.enum_type.is_empty() {
+      self.state.error_message = Some("Please select an enum type".to_string());
+      return;
+    }
+
+    // Parse field length (only for STRING type)
+    let field_length =
+      if !self.field_length_hidden { self.field_length.parse::<u16>().ok() } else { None };
+
+    // Get enum type storage
+    let enum_type_storage =
+      if self.enum_type_storage_index == 0 { JavaEnumType::Ordinal } else { JavaEnumType::String };
+
+    // Build field config
+    let field_config = EnumFieldConfig {
+      field_name: self.field_name.clone(),
+      enum_type: self.enum_type.clone(),
+      enum_package_name: self.enum_package_name.clone(),
+      enum_type_storage,
+      field_length,
+      field_nullable: !self.mandatory,
+      field_unique: self.unique,
+    };
+
+    // Call service
+    match create_jpa_entity_enum_field_service::run(
+      &self.cwd,
+      &self.entity_file_b64_src,
+      &self.entity_file_path,
+      field_config,
+    ) {
+      Ok(response) => {
+        eprintln!(
+          "Successfully created enum field {} in {} at {}",
+          self.field_name, response.file_type, response.file_path
+        );
+        self.state.should_quit = true;
+        std::process::exit(0);
+      }
+      Err(e) => {
+        self.state.error_message = Some(format!("Error: {}", e));
+      }
+    }
+  }
+
+  fn render_enum_type_selector(&mut self, frame: &mut Frame, area: Rect) {
+    let is_focused = self.focused_field == FocusedField::EnumType;
+
+    let items: Vec<ListItem> = if self.all_enum_types.is_empty() {
+      vec![ListItem::new(" No enum types available")]
+    } else {
+      self
+        .all_enum_types
+        .iter()
+        .enumerate()
+        .map(|(i, enum_info)| {
+          let is_selected = self.enum_type_state.selected() == Some(i);
+          let prefix = if is_selected { "●" } else { "○" };
+          let display = format!("{} ({})", enum_info.file_type, enum_info.file_package_name);
+          ListItem::new(format!(" {} {}", prefix, display))
+        })
+        .collect()
+    };
+
+    let border_style =
+      if is_focused { Style::default().fg(Color::Yellow) } else { Style::default() };
+
+    let title = self.generate_title("Enum type", is_focused);
+    let list = List::new(items)
+      .block(Block::default().title(title).borders(Borders::ALL).border_style(border_style))
+      .highlight_style(Style::default().bg(Color::DarkGray).add_modifier(Modifier::BOLD))
+      .highlight_symbol(">> ");
+
+    frame.render_stateful_widget(list, area, &mut self.enum_type_state);
+  }
+
+  fn render_enum_type_storage_selector(&mut self, frame: &mut Frame, area: Rect) {
+    let is_focused = self.focused_field == FocusedField::EnumTypeStorage;
+
+    // JavaEnumType has 2 variants: Ordinal and String
+    let items: Vec<ListItem> = vec![
+      {
+        let is_selected = self.enum_type_storage_state.selected() == Some(0);
+        let prefix = if is_selected { "●" } else { "○" };
+        ListItem::new(format!(" {} ORDINAL", prefix))
+      },
+      {
+        let is_selected = self.enum_type_storage_state.selected() == Some(1);
+        let prefix = if is_selected { "●" } else { "○" };
+        ListItem::new(format!(" {} STRING", prefix))
+      },
+    ];
+
+    let border_style =
+      if is_focused { Style::default().fg(Color::Yellow) } else { Style::default() };
+
+    let title = self.generate_title("Enum type storage", is_focused);
+    let list = List::new(items)
+      .block(Block::default().title(title).borders(Borders::ALL).border_style(border_style))
+      .highlight_style(Style::default().bg(Color::DarkGray).add_modifier(Modifier::BOLD))
+      .highlight_symbol(">> ");
+
+    frame.render_stateful_widget(list, area, &mut self.enum_type_storage_state);
+  }
+
+  fn render_field_name_input(&mut self, frame: &mut Frame, area: Rect) {
+    let is_focused = self.focused_field == FocusedField::FieldName;
+    let border_style =
+      if is_focused { Style::default().fg(Color::Yellow) } else { Style::default() };
+    let title = self.generate_title("Field name", is_focused);
+    let input = Paragraph::new(self.field_name.as_str())
+      .block(Block::default().title(title).borders(Borders::ALL).border_style(border_style));
+    frame.render_widget(input, area);
+    if is_focused && self.state.input_mode == InputMode::Insert {
+      frame.set_cursor_position((area.x + self.field_name_cursor as u16 + 1, area.y + 1));
+    }
+  }
+
+  fn render_field_length_input(&mut self, frame: &mut Frame, area: Rect) {
+    if self.field_length_hidden {
+      return;
+    }
+
+    let is_focused = self.focused_field == FocusedField::FieldLength;
+    let border_style =
+      if is_focused { Style::default().fg(Color::Yellow) } else { Style::default() };
+    let title = self.generate_title("Field length", is_focused);
+    let input = Paragraph::new(self.field_length.as_str())
+      .block(Block::default().title(title).borders(Borders::ALL).border_style(border_style));
+    frame.render_widget(input, area);
+    if is_focused && self.state.input_mode == InputMode::Insert {
+      frame.set_cursor_position((area.x + self.field_length_cursor as u16 + 1, area.y + 1));
+    }
+  }
+
+  fn render_other_options_selector(&mut self, frame: &mut Frame, area: Rect) {
+    let is_focused = self.focused_field == FocusedField::OtherOptions;
+
+    let items = vec![
+      ListItem::new(format!(" [{}] Mandatory", if self.mandatory { "x" } else { " " })),
+      ListItem::new(format!(" [{}] Unique", if self.unique { "x" } else { " " })),
+    ];
+
+    let border_style =
+      if is_focused { Style::default().fg(Color::Yellow) } else { Style::default() };
+
+    let title = self.generate_title("Other options (Space to toggle)", is_focused);
+    let list = List::new(items)
+      .block(Block::default().title(title).borders(Borders::ALL).border_style(border_style))
+      .highlight_style(Style::default().bg(Color::DarkGray).add_modifier(Modifier::BOLD))
+      .highlight_symbol(">> ");
+
+    frame.render_stateful_widget(list, area, &mut self.other_options_state);
+  }
+
+  fn render_buttons(&self, frame: &mut Frame, area: Rect) {
+    let chunks = Layout::default()
+      .direction(Direction::Horizontal)
+      .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+      .split(area);
+
+    // Render Back button
+    let is_back_focused = self.focused_field == FocusedField::BackButton;
+    let back_color = if self.back_pressed_once { Color::Red } else { Color::Yellow };
+    let back_text = if self.back_pressed_once { "Press again to go back" } else { "Back" };
+    let back_style = if is_back_focused {
+      Style::default().bg(back_color).fg(Color::Black).add_modifier(Modifier::BOLD)
+    } else {
+      Style::default().fg(back_color)
+    };
+    let back_button = Paragraph::new(format!("[ {} ]", back_text))
+      .alignment(Alignment::Center)
+      .style(back_style)
+      .block(Block::default().borders(Borders::empty()));
+    frame.render_widget(back_button, chunks[0]);
+
+    // Render Confirm button
+    let is_confirm_focused = self.focused_field == FocusedField::ConfirmButton;
+    let color = match self.state.escape_handler.pressed_once {
+      true => Color::Red,
+      false => Color::Green,
+    };
+    let text = match self.state.escape_handler.pressed_once {
+      true => "Press esc again to close or any key to return",
+      false => "Confirm",
+    };
+    let confirm_style = if is_confirm_focused {
+      Style::default().bg(color).fg(Color::Black).add_modifier(Modifier::BOLD)
+    } else {
+      Style::default().fg(color)
+    };
+    let confirm_button = Paragraph::new(format!("[ {} ]", text))
+      .alignment(Alignment::Center)
+      .style(confirm_style)
+      .block(Block::default().borders(Borders::empty()));
+    frame.render_widget(confirm_button, chunks[1]);
+  }
+
+  fn render_title_bar(&self, frame: &mut Frame, area: Rect) {
+    let title_text = "Create new JPA Entity enum field";
+    let title = Paragraph::new(title_text)
+      .alignment(Alignment::Center)
+      .style(Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD))
+      .block(Block::default().borders(Borders::BOTTOM));
+    frame.render_widget(title, area);
+  }
+
+  pub fn render(&mut self, frame: &mut Frame) {
+    let area = frame.area();
+
+    let enum_type_height = (self.all_enum_types.len() as u16 + 2).clamp(7, 15);
+    let length_height = if self.field_length_hidden { 0 } else { 3 };
+
+    let mut constraints = vec![
+      Constraint::Length(2),                // Title bar
+      Constraint::Length(enum_type_height), // Enum type selector
+      Constraint::Length(4),                // Enum type storage selector
+      Constraint::Length(3),                // Field name input
+    ];
+
+    if length_height > 0 {
+      constraints.push(Constraint::Length(length_height));
+    }
+
+    constraints.push(Constraint::Length(4)); // Other options
+    constraints.push(Constraint::Min(0)); // Flexible space for errors
+    constraints.push(Constraint::Length(1)); // Buttons
+
+    let chunks =
+      Layout::default().direction(Direction::Vertical).constraints(constraints).split(area);
+
+    let mut chunk_idx = 0;
+
+    self.render_title_bar(frame, chunks[chunk_idx]);
+    chunk_idx += 1;
+
+    self.render_enum_type_selector(frame, chunks[chunk_idx]);
+    chunk_idx += 1;
+
+    self.render_enum_type_storage_selector(frame, chunks[chunk_idx]);
+    chunk_idx += 1;
+
+    self.render_field_name_input(frame, chunks[chunk_idx]);
+    chunk_idx += 1;
+
+    if length_height > 0 {
+      self.render_field_length_input(frame, chunks[chunk_idx]);
+      chunk_idx += 1;
+    }
+
+    self.render_other_options_selector(frame, chunks[chunk_idx]);
+    chunk_idx += 1;
+
+    // Render error message if present
+    if let Some(ref error_msg) = self.state.error_message {
+      let error_paragraph =
+        Paragraph::new(error_msg.as_str()).style(Style::default().fg(Color::Red)).block(
+          Block::default()
+            .title("Error")
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(Color::Red)),
+        );
+      frame.render_widget(error_paragraph, chunks[chunk_idx]);
+    }
+    chunk_idx += 1;
+
+    self.render_buttons(frame, chunks[chunk_idx]);
+  }
+
+  /// Check if user wants to go back to category selection
+  pub fn should_go_back(&self) -> bool {
+    self.should_go_back
+  }
+}
+
+// Implement the FormBehavior trait to get inherited methods
+impl FormBehavior for CreateEnumFieldForm {
+  fn form_state(&self) -> &FormState {
+    &self.state
+  }
+
+  fn form_state_mut(&mut self) -> &mut FormState {
+    &mut self.state
+  }
+
+  fn focus_next(&mut self) {
+    CreateEnumFieldForm::focus_next(self)
+  }
+
+  fn focus_prev(&mut self) {
+    CreateEnumFieldForm::focus_prev(self)
+  }
+
+  fn on_enter_insert_mode(&mut self, key: KeyCode) {
+    CreateEnumFieldForm::on_enter_insert_mode(self, key)
+  }
+
+  fn on_enter_pressed(&mut self) {
+    CreateEnumFieldForm::on_enter_pressed(self)
+  }
+
+  fn handle_field_insert(&mut self, key: KeyCode) {
+    CreateEnumFieldForm::handle_field_insert(self, key)
+  }
+
+  fn handle_normal_mode(&mut self, key: KeyCode) {
+    // Handle Ctrl+Enter (F1 signal) - always confirm
+    if key == KeyCode::F(1) {
+      self.execute_create_enum_field();
+      return;
+    }
+
+    // Handle Ctrl+Backspace (F2 signal) - same as pressing back button
+    if key == KeyCode::F(2) {
+      if self.back_pressed_once {
+        self.should_go_back = true;
+      } else {
+        self.back_pressed_once = true;
+      }
+      return;
+    }
+
+    // Reset back button confirmation on any other key
+    self.back_pressed_once = false;
+
+    // Default behavior for other keys
+    match key {
+      KeyCode::Char('j') | KeyCode::Tab => self.focus_next(),
+      KeyCode::Char('k') | KeyCode::BackTab => self.focus_prev(),
+      KeyCode::Char('i') | KeyCode::Char('a') => {
+        self.on_enter_insert_mode(key);
+        self.set_input_mode(InputMode::Insert);
+      }
+      KeyCode::Enter => self.on_enter_pressed(),
+      _ => {}
+    }
+  }
+
+  fn render(&mut self, frame: &mut Frame) {
+    CreateEnumFieldForm::render(self, frame)
+  }
+}

--- a/src/ui/forms/create_id_field.rs
+++ b/src/ui/forms/create_id_field.rs
@@ -1,0 +1,1114 @@
+#![allow(dead_code)]
+
+use clap::ValueEnum;
+use crossterm::event::KeyCode;
+use ratatui::{
+  Frame,
+  layout::{Alignment, Constraint, Direction, Layout, Rect},
+  style::{Color, Modifier, Style},
+  widgets::{Block, Borders, List, ListItem, ListState, Paragraph},
+};
+use std::path::{Path, PathBuf};
+
+use crate::commands::services::create_jpa_entity_id_field_service;
+use crate::commands::{get_java_basic_types_command, get_jpa_entity_info_command};
+use crate::common::types::id_field_config::IdFieldConfig;
+use crate::common::types::java_basic_types::JavaBasicType;
+use crate::common::types::java_id_generation::JavaIdGeneration;
+use crate::common::types::java_id_generation_type::JavaIdGenerationType;
+use crate::responses::basic_java_type_response::JavaBasicTypeResponse;
+use crate::ui::form_trait::{FormBehavior, FormState, InputMode, helpers};
+
+/// ID Generation Strategy options
+#[derive(Debug, Clone, Copy, PartialEq, ValueEnum)]
+enum IdGeneration {
+  None,
+  Auto,
+  Identity,
+  Sequence,
+  Uuid,
+}
+
+impl IdGeneration {
+  fn all() -> Vec<IdGeneration> {
+    vec![
+      IdGeneration::None,
+      IdGeneration::Auto,
+      IdGeneration::Identity,
+      IdGeneration::Sequence,
+      IdGeneration::Uuid,
+    ]
+  }
+
+  fn as_str(&self) -> &'static str {
+    match self {
+      IdGeneration::None => "None (Manual)",
+      IdGeneration::Auto => "Auto",
+      IdGeneration::Identity => "Identity",
+      IdGeneration::Sequence => "Sequence",
+      IdGeneration::Uuid => "UUID",
+    }
+  }
+}
+
+/// Generation Type options (for sequence generation)
+#[derive(Debug, Clone, Copy, PartialEq, ValueEnum)]
+enum GenerationType {
+  OrmProvided,
+  EntityExclusiveGeneration,
+}
+
+impl GenerationType {
+  fn all() -> Vec<GenerationType> {
+    vec![GenerationType::OrmProvided, GenerationType::EntityExclusiveGeneration]
+  }
+
+  fn as_str(&self) -> &'static str {
+    match self {
+      GenerationType::OrmProvided => "ORM Provided",
+      GenerationType::EntityExclusiveGeneration => "Entity Exclusive Generation",
+    }
+  }
+}
+
+/// Represents which field is currently focused
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum FocusedField {
+  FieldType,
+  FieldName,
+  IdGeneration,
+  GenerationType,
+  GeneratorName,
+  SequenceName,
+  InitialValue,
+  AllocationSize,
+  OtherOptions,
+  BackButton,
+  ConfirmButton,
+}
+
+/// Main form state for creating an ID field
+pub struct CreateIdFieldForm {
+  // Common form state (embedded)
+  state: FormState,
+
+  // Field values
+  field_type_index: usize,
+  field_package_path: Option<String>,
+  field_type: String,
+  field_name: String,
+  id_generation_index: usize,
+  id_generation: IdGeneration,
+  generation_type_index: usize,
+  generation_type: GenerationType,
+  generator_name: String,
+  sequence_name: String,
+  initial_value: String,
+  allocation_size: String,
+
+  // Other options (checkboxes)
+  mandatory: bool,
+  mutable: bool,
+
+  // Type lists
+  all_id_types: Vec<JavaBasicTypeResponse>,
+
+  // List states
+  field_type_state: ListState,
+  id_generation_state: ListState,
+  generation_type_state: ListState,
+  other_options_state: ListState,
+
+  // Text input states
+  field_name_cursor: usize,
+  generator_name_cursor: usize,
+  sequence_name_cursor: usize,
+  initial_value_cursor: usize,
+  allocation_size_cursor: usize,
+
+  // Visibility flags
+  id_generation_hidden: bool,
+  generation_type_hidden: bool,
+  generator_name_hidden: bool,
+  sequence_name_hidden: bool,
+  initial_value_hidden: bool,
+  allocation_size_hidden: bool,
+
+  // Focus management
+  focused_field: FocusedField,
+
+  // Integration with syntaxpresso-core
+  cwd: PathBuf,
+  entity_file_b64_src: String,
+  entity_file_path: PathBuf,
+
+  // Navigation
+  should_go_back: bool,
+  back_pressed_once: bool,
+}
+
+impl CreateIdFieldForm {
+  pub fn new(cwd: PathBuf, entity_file_b64_src: String, entity_file_path: PathBuf) -> Self {
+    // Fetch ID types from syntaxpresso-core
+    let all_id_types = match Self::fetch_id_types() {
+      Ok(types) => types,
+      Err(_e) => Self::get_default_id_types(),
+    };
+
+    let all_id_types =
+      if all_id_types.is_empty() { Self::get_default_id_types() } else { all_id_types };
+
+    assert!(!all_id_types.is_empty(), "all_id_types must not be empty!");
+
+    // Fetch entity info to generate generator and sequence names
+    let (generator_name, sequence_name) = match Self::fetch_entity_info(&cwd, &entity_file_path) {
+      Ok((entity_table_name, entity_type)) => {
+        // Use table name if available, otherwise derive from entity type
+        let base_name = if let Some(table_name) = entity_table_name {
+          table_name
+        } else {
+          // Convert EntityName to entityName (camelCase)
+          let mut chars = entity_type.chars();
+          if let Some(first) = chars.next() {
+            format!("{}{}", first.to_lowercase(), chars.collect::<String>())
+          } else {
+            "entity".to_string()
+          }
+        };
+        (format!("{}_gen", base_name), format!("{}_seq", base_name))
+      }
+      Err(_) => (String::new(), String::new()),
+    };
+
+    let generator_name_cursor = generator_name.len();
+    let sequence_name_cursor = sequence_name.len();
+
+    let mut field_type_state = ListState::default();
+    field_type_state.select(Some(0));
+
+    let mut id_generation_state = ListState::default();
+    id_generation_state.select(Some(1)); // Default to Auto
+
+    let mut generation_type_state = ListState::default();
+    generation_type_state.select(Some(0)); // Default to OrmProvided
+
+    let mut other_options_state = ListState::default();
+    other_options_state.select(Some(0));
+
+    // Default to Long type
+    let (default_package, default_type) = if !all_id_types.is_empty() {
+      (all_id_types[0].package_path.clone(), all_id_types[0].name.clone())
+    } else {
+      (Some("java.lang".to_string()), "Long".to_string())
+    };
+
+    let mut form = Self {
+      state: FormState::new(),
+      field_type_index: 0,
+      field_package_path: default_package,
+      field_type: default_type,
+      field_name: "id".to_string(),
+      id_generation_index: 1, // Auto
+      id_generation: IdGeneration::Auto,
+      generation_type_index: 0, // OrmProvided
+      generation_type: GenerationType::OrmProvided,
+      generator_name,
+      sequence_name,
+      initial_value: "1".to_string(),
+      allocation_size: "50".to_string(),
+      mandatory: true,
+      mutable: false,
+      all_id_types,
+      field_type_state,
+      id_generation_state,
+      generation_type_state,
+      other_options_state,
+      field_name_cursor: 2, // "id".len()
+      generator_name_cursor,
+      sequence_name_cursor,
+      initial_value_cursor: 1,
+      allocation_size_cursor: 2,
+      id_generation_hidden: false,
+      generation_type_hidden: true,
+      generator_name_hidden: true,
+      sequence_name_hidden: true,
+      initial_value_hidden: true,
+      allocation_size_hidden: true,
+      focused_field: FocusedField::FieldType,
+      cwd,
+      entity_file_b64_src,
+      entity_file_path,
+      should_go_back: false,
+      back_pressed_once: false,
+    };
+
+    // Update field type to set correct visibility flags
+    form.update_field_type();
+
+    form
+  }
+
+  /// Get default fallback ID types when fetching fails
+  fn get_default_id_types() -> Vec<JavaBasicTypeResponse> {
+    vec![
+      JavaBasicTypeResponse {
+        id: "java.lang.Long".to_string(),
+        name: "Long".to_string(),
+        package_path: Some("java.lang".to_string()),
+      },
+      JavaBasicTypeResponse {
+        id: "java.lang.Integer".to_string(),
+        name: "Integer".to_string(),
+        package_path: Some("java.lang".to_string()),
+      },
+      JavaBasicTypeResponse {
+        id: "java.util.UUID".to_string(),
+        name: "UUID".to_string(),
+        package_path: Some("java.util".to_string()),
+      },
+    ]
+  }
+
+  /// Fetch ID types from syntaxpresso-core
+  fn fetch_id_types() -> Result<Vec<JavaBasicTypeResponse>, Box<dyn std::error::Error>> {
+    let response = get_java_basic_types_command::execute(&JavaBasicType::IdTypes);
+
+    if let Some(types) = response.data { Ok(types) } else { Ok(Vec::new()) }
+  }
+
+  /// Fetch JPA entity info to generate generator and sequence names
+  /// Returns (table_name, entity_type)
+  fn fetch_entity_info(
+    cwd: &Path,
+    entity_file_path: &Path,
+  ) -> Result<(Option<String>, String), Box<dyn std::error::Error>> {
+    let response =
+      get_jpa_entity_info_command::execute(cwd, Some(entity_file_path), None);
+
+    if let Some(data) = response.data {
+      Ok((data.entity_table_name, data.entity_type))
+    } else {
+      Err("Failed to fetch entity info".into())
+    }
+  }
+
+  /// Update field type and related visibility flags
+  fn update_field_type(&mut self) {
+    if let Some(idx) = self.field_type_state.selected() && let Some(type_info) = self.all_id_types.get(idx) {
+      self.field_type_index = idx;
+      self.field_type = type_info.name.clone();
+      self.field_package_path = type_info.package_path.clone();
+
+      // UUID type can ONLY use uuid generation
+      if type_info.name == "UUID" {
+        self.id_generation = IdGeneration::Uuid;
+        self.id_generation_hidden = true;
+        self.generation_type_hidden = true;
+        self.generator_name_hidden = true;
+        self.sequence_name_hidden = true;
+        self.initial_value_hidden = true;
+        self.allocation_size_hidden = true;
+      } else {
+        // Numeric types: show generation options, default to auto
+        self.id_generation = IdGeneration::Auto;
+        self.id_generation_hidden = false;
+        self.generation_type_hidden = true;
+        self.generator_name_hidden = true;
+        self.sequence_name_hidden = true;
+        self.initial_value_hidden = true;
+        self.allocation_size_hidden = true;
+      }
+    }
+  }
+
+  /// Update ID generation and related visibility flags
+  fn update_id_generation(&mut self) {
+    if let Some(idx) = self.id_generation_state.selected() {
+      let all_generations = IdGeneration::all();
+      if let Some(generation) = all_generations.get(idx) {
+        self.id_generation_index = idx;
+        self.id_generation = *generation;
+
+        // Only SEQUENCE generation uses generation type and related fields
+        if *generation == IdGeneration::Sequence {
+          self.generation_type_hidden = false;
+          self.generation_type = GenerationType::OrmProvided;
+          // Initially hide sequence-specific fields
+          self.generator_name_hidden = true;
+          self.sequence_name_hidden = true;
+          self.initial_value_hidden = true;
+          self.allocation_size_hidden = true;
+        } else {
+          // none, auto, identity, uuid: hide all sequence-related fields
+          self.generation_type_hidden = true;
+          self.generator_name_hidden = true;
+          self.sequence_name_hidden = true;
+          self.initial_value_hidden = true;
+          self.allocation_size_hidden = true;
+        }
+      }
+    }
+  }
+
+  /// Update generation type and related visibility flags
+  fn update_generation_type(&mut self) {
+    if let Some(idx) = self.generation_type_state.selected() {
+      let all_types = GenerationType::all();
+      if let Some(gen_type) = all_types.get(idx) {
+        self.generation_type_index = idx;
+        self.generation_type = *gen_type;
+
+        // Only entity_exclusive_generation requires generator/sequence configuration
+        if *gen_type == GenerationType::EntityExclusiveGeneration {
+          self.generator_name_hidden = false;
+          self.sequence_name_hidden = false;
+          self.initial_value_hidden = false;
+          self.allocation_size_hidden = false;
+        } else {
+          // orm_provided: hide all custom generator fields
+          self.generator_name_hidden = true;
+          self.sequence_name_hidden = true;
+          self.initial_value_hidden = true;
+          self.allocation_size_hidden = true;
+        }
+      }
+    }
+  }
+
+  /// Move focus to the next visible field
+  fn focus_next(&mut self) {
+    // Reset back button confirmation when focus changes
+    self.back_pressed_once = false;
+
+    loop {
+      self.focused_field = match self.focused_field {
+        FocusedField::FieldType => FocusedField::FieldName,
+        FocusedField::FieldName => FocusedField::IdGeneration,
+        FocusedField::IdGeneration => FocusedField::GenerationType,
+        FocusedField::GenerationType => FocusedField::GeneratorName,
+        FocusedField::GeneratorName => FocusedField::SequenceName,
+        FocusedField::SequenceName => FocusedField::InitialValue,
+        FocusedField::InitialValue => FocusedField::AllocationSize,
+        FocusedField::AllocationSize => FocusedField::OtherOptions,
+        FocusedField::OtherOptions => FocusedField::BackButton,
+        FocusedField::BackButton => FocusedField::ConfirmButton,
+        FocusedField::ConfirmButton => FocusedField::FieldType,
+      };
+
+      // Skip hidden fields
+      if !self.is_field_hidden(self.focused_field) {
+        break;
+      }
+    }
+  }
+
+  /// Move focus to the previous visible field
+  fn focus_prev(&mut self) {
+    // Reset back button confirmation when focus changes
+    self.back_pressed_once = false;
+
+    loop {
+      self.focused_field = match self.focused_field {
+        FocusedField::FieldType => FocusedField::ConfirmButton,
+        FocusedField::FieldName => FocusedField::FieldType,
+        FocusedField::IdGeneration => FocusedField::FieldName,
+        FocusedField::GenerationType => FocusedField::IdGeneration,
+        FocusedField::GeneratorName => FocusedField::GenerationType,
+        FocusedField::SequenceName => FocusedField::GeneratorName,
+        FocusedField::InitialValue => FocusedField::SequenceName,
+        FocusedField::AllocationSize => FocusedField::InitialValue,
+        FocusedField::OtherOptions => FocusedField::AllocationSize,
+        FocusedField::BackButton => FocusedField::OtherOptions,
+        FocusedField::ConfirmButton => FocusedField::BackButton,
+      };
+
+      // Skip hidden fields
+      if !self.is_field_hidden(self.focused_field) {
+        break;
+      }
+    }
+  }
+
+  /// Check if a field is hidden
+  fn is_field_hidden(&self, field: FocusedField) -> bool {
+    match field {
+      FocusedField::IdGeneration => self.id_generation_hidden,
+      FocusedField::GenerationType => self.generation_type_hidden,
+      FocusedField::GeneratorName => self.generator_name_hidden,
+      FocusedField::SequenceName => self.sequence_name_hidden,
+      FocusedField::InitialValue => self.initial_value_hidden,
+      FocusedField::AllocationSize => self.allocation_size_hidden,
+      _ => false,
+    }
+  }
+
+  /// Called when entering insert mode
+  fn on_enter_insert_mode(&mut self, key: KeyCode) {
+    if key == KeyCode::Char('a') {
+      match self.focused_field {
+        FocusedField::FieldName => {
+          self.field_name_cursor = self.field_name.len();
+        }
+        FocusedField::GeneratorName => {
+          self.generator_name_cursor = self.generator_name.len();
+        }
+        FocusedField::SequenceName => {
+          self.sequence_name_cursor = self.sequence_name.len();
+        }
+        FocusedField::InitialValue => {
+          self.initial_value_cursor = self.initial_value.len();
+        }
+        FocusedField::AllocationSize => {
+          self.allocation_size_cursor = self.allocation_size.len();
+        }
+        _ => {}
+      }
+    }
+  }
+
+  /// Called when Enter is pressed in Normal mode
+  fn on_enter_pressed(&mut self) {
+    match self.focused_field {
+      FocusedField::ConfirmButton => {
+        self.execute_create_id_field();
+      }
+      FocusedField::BackButton => {
+        if self.back_pressed_once {
+          self.should_go_back = true;
+        } else {
+          self.back_pressed_once = true;
+        }
+      }
+      _ => {}
+    }
+  }
+
+  /// Handle field-specific input in Insert mode
+  fn handle_field_insert(&mut self, key: KeyCode) {
+    match self.focused_field {
+      FocusedField::FieldType => self.handle_field_type_insert(key),
+      FocusedField::FieldName => self.handle_field_name_input(key),
+      FocusedField::IdGeneration => self.handle_id_generation_insert(key),
+      FocusedField::GenerationType => self.handle_generation_type_insert(key),
+      FocusedField::GeneratorName => self.handle_generator_name_input(key),
+      FocusedField::SequenceName => self.handle_sequence_name_input(key),
+      FocusedField::InitialValue => self.handle_initial_value_input(key),
+      FocusedField::AllocationSize => self.handle_allocation_size_input(key),
+      FocusedField::OtherOptions => self.handle_other_options_insert(key),
+      FocusedField::BackButton => {
+        if key == KeyCode::Enter {
+          if self.back_pressed_once {
+            self.should_go_back = true;
+          } else {
+            self.back_pressed_once = true;
+          }
+        }
+      }
+      FocusedField::ConfirmButton => {
+        if key == KeyCode::Enter {
+          self.execute_create_id_field();
+        }
+      }
+    }
+  }
+
+  fn handle_field_type_insert(&mut self, key: KeyCode) {
+    match key {
+      KeyCode::Char('j') | KeyCode::Down => {
+        let len = self.all_id_types.len();
+        helpers::navigate_list_static(&KeyCode::Down, &mut self.field_type_state, len);
+        self.update_field_type();
+      }
+      KeyCode::Char('k') | KeyCode::Up => {
+        let len = self.all_id_types.len();
+        helpers::navigate_list_static(&KeyCode::Up, &mut self.field_type_state, len);
+        self.update_field_type();
+      }
+      KeyCode::Enter => {
+        self.state.input_mode = InputMode::Normal;
+      }
+      _ => {}
+    }
+  }
+
+  fn handle_field_name_input(&mut self, key: KeyCode) {
+    match key {
+      KeyCode::Char(c) => {
+        self.field_name.insert(self.field_name_cursor, c);
+        self.field_name_cursor += 1;
+      }
+      KeyCode::Backspace => {
+        if self.field_name_cursor > 0 {
+          self.field_name.remove(self.field_name_cursor - 1);
+          self.field_name_cursor -= 1;
+        }
+      }
+      KeyCode::Delete => {
+        if self.field_name_cursor < self.field_name.len() {
+          self.field_name.remove(self.field_name_cursor);
+        }
+      }
+      KeyCode::Left => {
+        if self.field_name_cursor > 0 {
+          self.field_name_cursor -= 1;
+        }
+      }
+      KeyCode::Right => {
+        if self.field_name_cursor < self.field_name.len() {
+          self.field_name_cursor += 1;
+        }
+      }
+      KeyCode::Home => {
+        self.field_name_cursor = 0;
+      }
+      KeyCode::End => {
+        self.field_name_cursor = self.field_name.len();
+      }
+      KeyCode::Enter => {
+        self.state.input_mode = InputMode::Normal;
+      }
+      _ => {}
+    }
+  }
+
+  fn handle_id_generation_insert(&mut self, key: KeyCode) {
+    match key {
+      KeyCode::Char('j') | KeyCode::Down => {
+        let len = IdGeneration::all().len();
+        helpers::navigate_list_static(&KeyCode::Down, &mut self.id_generation_state, len);
+        self.update_id_generation();
+      }
+      KeyCode::Char('k') | KeyCode::Up => {
+        let len = IdGeneration::all().len();
+        helpers::navigate_list_static(&KeyCode::Up, &mut self.id_generation_state, len);
+        self.update_id_generation();
+      }
+      KeyCode::Enter => {
+        self.state.input_mode = InputMode::Normal;
+      }
+      _ => {}
+    }
+  }
+
+  fn handle_generation_type_insert(&mut self, key: KeyCode) {
+    match key {
+      KeyCode::Char('j') | KeyCode::Down => {
+        let len = GenerationType::all().len();
+        helpers::navigate_list_static(&KeyCode::Down, &mut self.generation_type_state, len);
+        self.update_generation_type();
+      }
+      KeyCode::Char('k') | KeyCode::Up => {
+        let len = GenerationType::all().len();
+        helpers::navigate_list_static(&KeyCode::Up, &mut self.generation_type_state, len);
+        self.update_generation_type();
+      }
+      KeyCode::Enter => {
+        self.state.input_mode = InputMode::Normal;
+      }
+      _ => {}
+    }
+  }
+
+  fn handle_generator_name_input(&mut self, key: KeyCode) {
+    helpers::handle_text_input(
+      key,
+      &mut self.generator_name,
+      &mut self.generator_name_cursor,
+      &mut self.state.input_mode,
+    );
+  }
+
+  fn handle_sequence_name_input(&mut self, key: KeyCode) {
+    helpers::handle_text_input(
+      key,
+      &mut self.sequence_name,
+      &mut self.sequence_name_cursor,
+      &mut self.state.input_mode,
+    );
+  }
+
+  fn handle_initial_value_input(&mut self, key: KeyCode) {
+    helpers::handle_numeric_input(
+      key,
+      &mut self.initial_value,
+      &mut self.initial_value_cursor,
+      &mut self.state.input_mode,
+    );
+  }
+
+  fn handle_allocation_size_input(&mut self, key: KeyCode) {
+    helpers::handle_numeric_input(
+      key,
+      &mut self.allocation_size,
+      &mut self.allocation_size_cursor,
+      &mut self.state.input_mode,
+    );
+  }
+
+  fn handle_other_options_insert(&mut self, key: KeyCode) {
+    match key {
+      KeyCode::Char('j') | KeyCode::Down => {
+        helpers::navigate_list_static(&KeyCode::Down, &mut self.other_options_state, 2);
+      }
+      KeyCode::Char('k') | KeyCode::Up => {
+        helpers::navigate_list_static(&KeyCode::Up, &mut self.other_options_state, 2);
+      }
+      KeyCode::Char(' ') | KeyCode::Enter => {
+        if let Some(idx) = self.other_options_state.selected() {
+          match idx {
+            0 => self.mandatory = !self.mandatory,
+            1 => self.mutable = !self.mutable,
+            _ => {}
+          }
+        }
+        if key == KeyCode::Enter {
+          self.state.input_mode = InputMode::Normal;
+        }
+      }
+      _ => {}
+    }
+  }
+
+  fn execute_create_id_field(&mut self) {
+    // Validate: entity_exclusive_generation requires generator_name
+    if self.id_generation == IdGeneration::Sequence
+      && self.generation_type == GenerationType::EntityExclusiveGeneration
+      && self.generator_name.is_empty()
+    {
+      self.state.error_message =
+        Some("Generator name is required for entity exclusive generation".to_string());
+      return;
+    }
+
+    // Parse numeric fields
+    let initial_value = self.initial_value.parse::<i64>().ok();
+    let allocation_size = self.allocation_size.parse::<i64>().ok();
+
+    // Convert generation strategy to enum
+    let field_id_generation = match self.id_generation {
+      IdGeneration::None => JavaIdGeneration::None,
+      IdGeneration::Auto => JavaIdGeneration::Auto,
+      IdGeneration::Identity => JavaIdGeneration::Identity,
+      IdGeneration::Sequence => JavaIdGeneration::Sequence,
+      IdGeneration::Uuid => JavaIdGeneration::Uuid,
+    };
+
+    // Convert generation type to enum (only relevant for sequence)
+    let field_id_generation_type = if self.id_generation == IdGeneration::Sequence {
+      match self.generation_type {
+        GenerationType::OrmProvided => JavaIdGenerationType::OrmProvided,
+        GenerationType::EntityExclusiveGeneration => {
+          JavaIdGenerationType::EntityExclusiveGeneration
+        }
+      }
+    } else {
+      JavaIdGenerationType::None
+    };
+
+    // Build field config
+    let field_config = IdFieldConfig {
+      field_name: self.field_name.clone(),
+      field_type: self.field_type.clone(),
+      field_type_package_name: self.field_package_path.clone(),
+      field_id_generation,
+      field_id_generation_type,
+      field_generator_name: if self.generator_name.is_empty() {
+        None
+      } else {
+        Some(self.generator_name.clone())
+      },
+      field_sequence_name: if self.sequence_name.is_empty() {
+        None
+      } else {
+        Some(self.sequence_name.clone())
+      },
+      field_initial_value: initial_value,
+      field_allocation_size: allocation_size,
+      field_nullable: !self.mandatory,
+    };
+
+    // Call service
+    match create_jpa_entity_id_field_service::run(
+      &self.cwd,
+      &self.entity_file_b64_src,
+      &self.entity_file_path,
+      field_config,
+    ) {
+      Ok(response) => {
+        eprintln!(
+          "Successfully created ID field {} in {} at {}",
+          self.field_name, response.file_type, response.file_path
+        );
+        self.state.should_quit = true;
+        std::process::exit(0);
+      }
+      Err(e) => {
+        self.state.error_message = Some(format!("Error: {}", e));
+      }
+    }
+  }
+
+  fn render_title_bar(&self, frame: &mut Frame, area: Rect) {
+    let title_text = "Create new JPA Entity ID field";
+    let title = Paragraph::new(title_text)
+      .alignment(Alignment::Center)
+      .style(Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD))
+      .block(Block::default().borders(Borders::BOTTOM));
+    frame.render_widget(title, area);
+  }
+
+  fn render_field_type_selector(&mut self, frame: &mut Frame, area: Rect) {
+    let is_focused = self.focused_field == FocusedField::FieldType;
+
+    let items: Vec<ListItem> = self
+      .all_id_types
+      .iter()
+      .enumerate()
+      .map(|(i, type_info)| {
+        let is_selected = self.field_type_state.selected() == Some(i);
+        let prefix = if is_selected { "●" } else { "○" };
+        let display =
+          format!("{} ({})", type_info.name, type_info.package_path.as_deref().unwrap_or(""));
+        ListItem::new(format!(" {} {}", prefix, display))
+      })
+      .collect();
+
+    let border_style =
+      if is_focused { Style::default().fg(Color::Yellow) } else { Style::default() };
+
+    let title = self.generate_title("Field type", is_focused);
+    let list = List::new(items)
+      .block(Block::default().title(title).borders(Borders::ALL).border_style(border_style))
+      .highlight_style(Style::default().bg(Color::DarkGray).add_modifier(Modifier::BOLD))
+      .highlight_symbol(">> ");
+
+    frame.render_stateful_widget(list, area, &mut self.field_type_state);
+  }
+
+  fn render_field_name_input(&mut self, frame: &mut Frame, area: Rect) {
+    let is_focused = self.focused_field == FocusedField::FieldName;
+    let border_style =
+      if is_focused { Style::default().fg(Color::Yellow) } else { Style::default() };
+    let title = self.generate_title("Field name", is_focused);
+    let input = Paragraph::new(self.field_name.as_str())
+      .block(Block::default().title(title).borders(Borders::ALL).border_style(border_style));
+    frame.render_widget(input, area);
+    if is_focused && self.state.input_mode == InputMode::Insert {
+      frame.set_cursor_position((area.x + self.field_name_cursor as u16 + 1, area.y + 1));
+    }
+  }
+
+  fn render_id_generation_selector(&mut self, frame: &mut Frame, area: Rect) {
+    if self.id_generation_hidden {
+      return;
+    }
+
+    let is_focused = self.focused_field == FocusedField::IdGeneration;
+    let all_generations = IdGeneration::all();
+
+    let items: Vec<ListItem> = all_generations
+      .iter()
+      .enumerate()
+      .map(|(i, generation)| {
+        let is_selected = self.id_generation_state.selected() == Some(i);
+        let prefix = if is_selected { "●" } else { "○" };
+        ListItem::new(format!(" {} {}", prefix, generation.as_str()))
+      })
+      .collect();
+
+    let border_style =
+      if is_focused { Style::default().fg(Color::Yellow) } else { Style::default() };
+
+    let title = self.generate_title("ID Generation Strategy", is_focused);
+    let list = List::new(items)
+      .block(Block::default().title(title).borders(Borders::ALL).border_style(border_style))
+      .highlight_style(Style::default().bg(Color::DarkGray).add_modifier(Modifier::BOLD))
+      .highlight_symbol(">> ");
+
+    frame.render_stateful_widget(list, area, &mut self.id_generation_state);
+  }
+
+  fn render_generation_type_selector(&mut self, frame: &mut Frame, area: Rect) {
+    if self.generation_type_hidden {
+      return;
+    }
+
+    let is_focused = self.focused_field == FocusedField::GenerationType;
+    let all_types = GenerationType::all();
+
+    let items: Vec<ListItem> = all_types
+      .iter()
+      .enumerate()
+      .map(|(i, gen_type)| {
+        let is_selected = self.generation_type_state.selected() == Some(i);
+        let prefix = if is_selected { "●" } else { "○" };
+        ListItem::new(format!(" {} {}", prefix, gen_type.as_str()))
+      })
+      .collect();
+
+    let border_style =
+      if is_focused { Style::default().fg(Color::Yellow) } else { Style::default() };
+
+    let title = self.generate_title("Generation Type", is_focused);
+    let list = List::new(items)
+      .block(Block::default().title(title).borders(Borders::ALL).border_style(border_style))
+      .highlight_style(Style::default().bg(Color::DarkGray).add_modifier(Modifier::BOLD))
+      .highlight_symbol(">> ");
+
+    frame.render_stateful_widget(list, area, &mut self.generation_type_state);
+  }
+
+  fn render_text_input(
+    &self,
+    frame: &mut Frame,
+    area: Rect,
+    label: &str,
+    value: &str,
+    cursor: usize,
+    is_focused: bool,
+  ) {
+    let border_style =
+      if is_focused { Style::default().fg(Color::Yellow) } else { Style::default() };
+    let title = self.generate_title(label, is_focused);
+    let input = Paragraph::new(value)
+      .block(Block::default().title(title).borders(Borders::ALL).border_style(border_style));
+    frame.render_widget(input, area);
+    if is_focused && self.state.input_mode == InputMode::Insert {
+      frame.set_cursor_position((area.x + cursor as u16 + 1, area.y + 1));
+    }
+  }
+
+  fn render_other_options_selector(&mut self, frame: &mut Frame, area: Rect) {
+    let is_focused = self.focused_field == FocusedField::OtherOptions;
+
+    let items = vec![
+      ListItem::new(format!(" [{}] Mandatory", if self.mandatory { "x" } else { " " })),
+      ListItem::new(format!(" [{}] Mutable", if self.mutable { "x" } else { " " })),
+    ];
+
+    let border_style =
+      if is_focused { Style::default().fg(Color::Yellow) } else { Style::default() };
+
+    let title = self.generate_title("Other options (Space to toggle)", is_focused);
+    let list = List::new(items)
+      .block(Block::default().title(title).borders(Borders::ALL).border_style(border_style))
+      .highlight_style(Style::default().bg(Color::DarkGray).add_modifier(Modifier::BOLD))
+      .highlight_symbol(">> ");
+
+    frame.render_stateful_widget(list, area, &mut self.other_options_state);
+  }
+
+  fn render_buttons(&self, frame: &mut Frame, area: Rect) {
+    let chunks = Layout::default()
+      .direction(Direction::Horizontal)
+      .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+      .split(area);
+
+    // Render Back button
+    let is_back_focused = self.focused_field == FocusedField::BackButton;
+    let back_color = if self.back_pressed_once { Color::Red } else { Color::Yellow };
+    let back_text = if self.back_pressed_once { "Press again to go back" } else { "Back" };
+    let back_style = if is_back_focused {
+      Style::default().bg(back_color).fg(Color::Black).add_modifier(Modifier::BOLD)
+    } else {
+      Style::default().fg(back_color)
+    };
+    let back_button = Paragraph::new(format!("[ {} ]", back_text))
+      .alignment(Alignment::Center)
+      .style(back_style)
+      .block(Block::default().borders(Borders::empty()));
+    frame.render_widget(back_button, chunks[0]);
+
+    // Render Confirm button
+    let is_confirm_focused = self.focused_field == FocusedField::ConfirmButton;
+    let color = match self.state.escape_handler.pressed_once {
+      true => Color::Red,
+      false => Color::Green,
+    };
+    let text = match self.state.escape_handler.pressed_once {
+      true => "Press esc again to close or any key to return",
+      false => "Confirm",
+    };
+    let confirm_style = if is_confirm_focused {
+      Style::default().bg(color).fg(Color::Black).add_modifier(Modifier::BOLD)
+    } else {
+      Style::default().fg(color)
+    };
+    let confirm_button = Paragraph::new(format!("[ {} ]", text))
+      .alignment(Alignment::Center)
+      .style(confirm_style)
+      .block(Block::default().borders(Borders::empty()));
+    frame.render_widget(confirm_button, chunks[1]);
+  }
+
+  pub fn render(&mut self, frame: &mut Frame) {
+    let area = frame.area();
+
+    let type_list_height = (self.all_id_types.len() as u16 + 2).clamp(5, 10);
+    let id_gen_height = if self.id_generation_hidden { 0 } else { 7 };
+    let gen_type_height = if self.generation_type_hidden { 0 } else { 4 };
+    let generator_height = if self.generator_name_hidden { 0 } else { 3 };
+    let sequence_height = if self.sequence_name_hidden { 0 } else { 3 };
+    let initial_height = if self.initial_value_hidden { 0 } else { 3 };
+    let allocation_height = if self.allocation_size_hidden { 0 } else { 3 };
+
+    let mut constraints = vec![
+      Constraint::Length(2),                // Title bar
+      Constraint::Length(type_list_height), // Field type selector
+      Constraint::Length(3),                // Field name input
+    ];
+
+    if id_gen_height > 0 {
+      constraints.push(Constraint::Length(id_gen_height));
+    }
+    if gen_type_height > 0 {
+      constraints.push(Constraint::Length(gen_type_height));
+    }
+    if generator_height > 0 {
+      constraints.push(Constraint::Length(generator_height));
+    }
+    if sequence_height > 0 {
+      constraints.push(Constraint::Length(sequence_height));
+    }
+    if initial_height > 0 {
+      constraints.push(Constraint::Length(initial_height));
+    }
+    if allocation_height > 0 {
+      constraints.push(Constraint::Length(allocation_height));
+    }
+
+    constraints.push(Constraint::Length(4)); // Other options
+    constraints.push(Constraint::Min(0)); // Flexible space for errors
+    constraints.push(Constraint::Length(1)); // Buttons
+
+    let chunks =
+      Layout::default().direction(Direction::Vertical).constraints(constraints).split(area);
+
+    let mut chunk_idx = 0;
+
+    self.render_title_bar(frame, chunks[chunk_idx]);
+    chunk_idx += 1;
+
+    self.render_field_type_selector(frame, chunks[chunk_idx]);
+    chunk_idx += 1;
+
+    self.render_field_name_input(frame, chunks[chunk_idx]);
+    chunk_idx += 1;
+
+    if id_gen_height > 0 {
+      self.render_id_generation_selector(frame, chunks[chunk_idx]);
+      chunk_idx += 1;
+    }
+
+    if gen_type_height > 0 {
+      self.render_generation_type_selector(frame, chunks[chunk_idx]);
+      chunk_idx += 1;
+    }
+
+    if generator_height > 0 {
+      self.render_text_input(
+        frame,
+        chunks[chunk_idx],
+        "Generator name (required)",
+        &self.generator_name,
+        self.generator_name_cursor,
+        self.focused_field == FocusedField::GeneratorName,
+      );
+      chunk_idx += 1;
+    }
+
+    if sequence_height > 0 {
+      self.render_text_input(
+        frame,
+        chunks[chunk_idx],
+        "Sequence name (optional)",
+        &self.sequence_name,
+        self.sequence_name_cursor,
+        self.focused_field == FocusedField::SequenceName,
+      );
+      chunk_idx += 1;
+    }
+
+    if initial_height > 0 {
+      self.render_text_input(
+        frame,
+        chunks[chunk_idx],
+        "Initial value (default: 1)",
+        &self.initial_value,
+        self.initial_value_cursor,
+        self.focused_field == FocusedField::InitialValue,
+      );
+      chunk_idx += 1;
+    }
+
+    if allocation_height > 0 {
+      self.render_text_input(
+        frame,
+        chunks[chunk_idx],
+        "Allocation size (default: 50)",
+        &self.allocation_size,
+        self.allocation_size_cursor,
+        self.focused_field == FocusedField::AllocationSize,
+      );
+      chunk_idx += 1;
+    }
+
+    self.render_other_options_selector(frame, chunks[chunk_idx]);
+    chunk_idx += 1;
+
+    // Render error message if present
+    if let Some(ref error_msg) = self.state.error_message {
+      let error_paragraph =
+        Paragraph::new(error_msg.as_str()).style(Style::default().fg(Color::Red)).block(
+          Block::default()
+            .title("Error")
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(Color::Red)),
+        );
+      frame.render_widget(error_paragraph, chunks[chunk_idx]);
+    }
+    chunk_idx += 1;
+
+    self.render_buttons(frame, chunks[chunk_idx]);
+  }
+
+  /// Check if user wants to go back to category selection
+  pub fn should_go_back(&self) -> bool {
+    self.should_go_back
+  }
+}
+
+// Implement the FormBehavior trait
+impl FormBehavior for CreateIdFieldForm {
+  fn form_state(&self) -> &FormState {
+    &self.state
+  }
+
+  fn form_state_mut(&mut self) -> &mut FormState {
+    &mut self.state
+  }
+
+  fn focus_next(&mut self) {
+    CreateIdFieldForm::focus_next(self)
+  }
+
+  fn focus_prev(&mut self) {
+    CreateIdFieldForm::focus_prev(self)
+  }
+
+  fn on_enter_insert_mode(&mut self, key: KeyCode) {
+    CreateIdFieldForm::on_enter_insert_mode(self, key)
+  }
+
+  fn on_enter_pressed(&mut self) {
+    CreateIdFieldForm::on_enter_pressed(self)
+  }
+
+  fn handle_field_insert(&mut self, key: KeyCode) {
+    CreateIdFieldForm::handle_field_insert(self, key)
+  }
+
+  fn render(&mut self, frame: &mut Frame) {
+    CreateIdFieldForm::render(self, frame)
+  }
+}

--- a/src/ui/forms/create_java_file.rs
+++ b/src/ui/forms/create_java_file.rs
@@ -1,0 +1,684 @@
+use clap::ValueEnum;
+use crossterm::event::KeyCode;
+use ratatui::{
+  Frame,
+  layout::{Alignment, Constraint, Direction, Layout, Rect},
+  style::{Color, Modifier, Style},
+  widgets::{Block, Borders, List, ListItem, ListState, Paragraph},
+};
+use std::path::{Path, PathBuf};
+
+use crate::commands::get_all_packages_command;
+use crate::commands::services::create_java_file_service;
+use crate::common::types::{
+  java_file_type::JavaFileType, java_source_directory_type::JavaSourceDirectoryType,
+};
+use crate::ui::form_trait::{FormBehavior, FormState, InputMode, helpers};
+
+/// Represents which field is currently focused
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum FocusedField {
+  FileType,
+  FileName,
+  PackageName,
+  ConfirmButton,
+}
+
+/// Main form state for creating a Java file
+pub struct CreateJavaFileForm {
+  // Common form state (embedded)
+  state: FormState,
+
+  // Field values (using enums for type safety!)
+  file_type: JavaFileType,
+  file_name: String,
+  package_name: String,
+
+  // File type state
+  file_type_state: ListState,
+
+  // Package autocomplete
+  package_list: Vec<String>,                  // All available packages
+  filtered_packages: Vec<String>,             // Filtered packages based on input
+  autocomplete_selected_index: Option<usize>, // Selected index in filtered list
+  autocomplete_scroll_offset: usize, // Scroll offset for autocomplete (which item is at top)
+  show_autocomplete: bool,           // Whether to show autocomplete dropdown
+
+  // Text input states
+  file_name_cursor: usize,
+  package_name_cursor: usize,
+
+  // Focus management
+  focused_field: FocusedField,
+
+  // Integration with syntaxpresso-core
+  cwd: PathBuf,
+}
+
+impl CreateJavaFileForm {
+  pub fn new(cwd: PathBuf) -> Self {
+    // Fetch packages directly from service
+    let package_list = Self::fetch_packages(&cwd).unwrap_or_else(|_| {
+      vec![
+        "com.example".to_string(),
+        "com.example.model".to_string(),
+        "com.example.service".to_string(),
+        "com.example.controller".to_string(),
+      ]
+    });
+
+    let mut file_type_state = ListState::default();
+    file_type_state.select(Some(0));
+
+    let default_package =
+      package_list.first().cloned().unwrap_or_else(|| "com.example".to_string());
+
+    Self {
+      state: FormState::new(),
+      // Use enum variants directly!
+      file_type: JavaFileType::Class,
+      file_name: "NewFile".to_string(),
+      package_name: default_package.clone(),
+      file_type_state,
+      package_list,
+      filtered_packages: Vec::new(),
+      autocomplete_selected_index: None,
+      autocomplete_scroll_offset: 0,
+      show_autocomplete: false,
+      file_name_cursor: 7, // Position at end of "NewFile"
+      package_name_cursor: default_package.len(),
+      focused_field: FocusedField::FileType,
+      cwd,
+    }
+  }
+
+  /// Fetch packages directly from service
+  fn fetch_packages(cwd: &Path) -> Result<Vec<String>, Box<dyn std::error::Error>> {
+    let response = get_all_packages_command::execute(cwd, &JavaSourceDirectoryType::Main);
+
+    if let Some(data) = response.data {
+      Ok(data.packages.iter().map(|p| p.package_name.clone()).collect())
+    } else {
+      Err("Failed to fetch packages".into())
+    }
+  }
+
+  /// Move focus to the next field
+  fn focus_next(&mut self) {
+    self.focused_field = match self.focused_field {
+      FocusedField::FileType => FocusedField::FileName,
+      FocusedField::FileName => FocusedField::PackageName,
+      FocusedField::PackageName => FocusedField::ConfirmButton,
+      FocusedField::ConfirmButton => FocusedField::FileType,
+    };
+  }
+
+  /// Move focus to the previous field
+  fn focus_prev(&mut self) {
+    self.focused_field = match self.focused_field {
+      FocusedField::FileType => FocusedField::ConfirmButton,
+      FocusedField::FileName => FocusedField::FileType,
+      FocusedField::PackageName => FocusedField::FileName,
+      FocusedField::ConfirmButton => FocusedField::PackageName,
+    };
+  }
+
+  /// Filter packages based on current input (for autocomplete)
+  fn filter_packages(&mut self) {
+    if self.package_name.is_empty() {
+      self.filtered_packages.clear();
+      self.show_autocomplete = false;
+      self.autocomplete_scroll_offset = 0;
+      return;
+    }
+
+    let input_lower = self.package_name.to_lowercase();
+
+    // Separate exact prefix matches and contains matches
+    let mut prefix_matches = Vec::new();
+    let mut contains_matches = Vec::new();
+
+    for package in &self.package_list {
+      let package_lower = package.to_lowercase();
+      if package_lower.starts_with(&input_lower) {
+        prefix_matches.push(package.clone());
+      } else if package_lower.contains(&input_lower) {
+        contains_matches.push(package.clone());
+      }
+    }
+
+    // Combine: prefix matches first, then contains matches
+    prefix_matches.sort();
+    contains_matches.sort();
+    prefix_matches.extend(contains_matches);
+
+    // Limit to top 7 suggestions
+    self.filtered_packages = prefix_matches.into_iter().take(7).collect();
+    self.show_autocomplete = !self.filtered_packages.is_empty();
+
+    // Reset selection and scroll if out of bounds
+    if let Some(idx) = self.autocomplete_selected_index && idx >= self.filtered_packages.len() {
+      self.autocomplete_selected_index = None;
+      self.autocomplete_scroll_offset = 0;
+    }
+  }
+
+  /// Called when entering insert mode - 'a' moves cursor to end for text inputs
+  fn on_enter_insert_mode(&mut self, key: KeyCode) {
+    if key == KeyCode::Char('a') {
+      match self.focused_field {
+        FocusedField::FileName => {
+          self.file_name_cursor = self.file_name.len();
+        }
+        FocusedField::PackageName => {
+          self.package_name_cursor = self.package_name.len();
+        }
+        _ => {}
+      }
+    }
+  }
+
+  /// Called when Enter is pressed in Normal mode
+  fn on_enter_pressed(&mut self) {
+    if self.focused_field == FocusedField::ConfirmButton {
+      self.execute_create_java_file();
+    }
+  }
+
+  /// Handle field-specific input in Insert mode
+  fn handle_field_insert(&mut self, key: KeyCode) {
+    match self.focused_field {
+      FocusedField::FileName => self.handle_file_name_input(key),
+      FocusedField::PackageName => self.handle_package_name_input(key),
+      FocusedField::FileType => self.handle_file_type_insert(key),
+      FocusedField::ConfirmButton => {
+        // Can't insert on button, exit insert mode
+        self.state.input_mode = InputMode::Normal;
+      }
+    }
+  }
+
+  fn handle_file_type_insert(&mut self, key: KeyCode) {
+    match key {
+      // Use j/k for navigation in insert mode
+      KeyCode::Char('j') | KeyCode::Down => {
+        let len = JavaFileType::value_variants().len();
+        helpers::navigate_list_static(&KeyCode::Down, &mut self.file_type_state, len);
+        self.update_file_type_value();
+      }
+      KeyCode::Char('k') | KeyCode::Up => {
+        let len = JavaFileType::value_variants().len();
+        helpers::navigate_list_static(&KeyCode::Up, &mut self.file_type_state, len);
+        self.update_file_type_value();
+      }
+      KeyCode::Enter => {
+        // Accept selection and exit insert mode
+        self.state.input_mode = InputMode::Normal;
+      }
+      _ => {}
+    }
+  }
+
+  fn handle_file_name_input(&mut self, key: KeyCode) {
+    match key {
+      KeyCode::Char(c) => {
+        self.file_name.insert(self.file_name_cursor, c);
+        self.file_name_cursor += 1;
+      }
+      KeyCode::Backspace => {
+        if self.file_name_cursor > 0 {
+          self.file_name.remove(self.file_name_cursor - 1);
+          self.file_name_cursor -= 1;
+        }
+      }
+      KeyCode::Delete => {
+        if self.file_name_cursor < self.file_name.len() {
+          self.file_name.remove(self.file_name_cursor);
+        }
+      }
+      KeyCode::Left => {
+        if self.file_name_cursor > 0 {
+          self.file_name_cursor -= 1;
+        }
+      }
+      KeyCode::Right => {
+        if self.file_name_cursor < self.file_name.len() {
+          self.file_name_cursor += 1;
+        }
+      }
+      KeyCode::Home => {
+        self.file_name_cursor = 0;
+      }
+      KeyCode::End => {
+        self.file_name_cursor = self.file_name.len();
+      }
+      _ => {}
+    }
+  }
+
+  fn handle_package_name_input(&mut self, key: KeyCode) {
+    match key {
+      KeyCode::Char(c) => {
+        self.package_name.insert(self.package_name_cursor, c);
+        self.package_name_cursor += 1;
+        // Update autocomplete suggestions
+        self.filter_packages();
+        self.autocomplete_selected_index = None;
+        self.autocomplete_scroll_offset = 0;
+      }
+      KeyCode::Backspace => {
+        if self.package_name_cursor > 0 {
+          self.package_name.remove(self.package_name_cursor - 1);
+          self.package_name_cursor -= 1;
+          // Update autocomplete suggestions
+          self.filter_packages();
+          self.autocomplete_selected_index = None;
+          self.autocomplete_scroll_offset = 0;
+        }
+      }
+      KeyCode::Delete => {
+        if self.package_name_cursor < self.package_name.len() {
+          self.package_name.remove(self.package_name_cursor);
+          // Update autocomplete suggestions
+          self.filter_packages();
+          self.autocomplete_selected_index = None;
+          self.autocomplete_scroll_offset = 0;
+        }
+      }
+      KeyCode::Left => {
+        if self.package_name_cursor > 0 {
+          self.package_name_cursor -= 1;
+        }
+      }
+      KeyCode::Right => {
+        if self.package_name_cursor < self.package_name.len() {
+          self.package_name_cursor += 1;
+        }
+      }
+      KeyCode::Home => {
+        self.package_name_cursor = 0;
+      }
+      KeyCode::End => {
+        self.package_name_cursor = self.package_name.len();
+      }
+      KeyCode::Down => {
+        // Navigate down in autocomplete suggestions
+        if self.show_autocomplete && !self.filtered_packages.is_empty() {
+          let new_idx = match self.autocomplete_selected_index {
+            None => 0,
+            Some(idx) => {
+              if idx + 1 < self.filtered_packages.len() {
+                idx + 1
+              } else {
+                0 // Wrap to top
+              }
+            }
+          };
+
+          self.autocomplete_selected_index = Some(new_idx);
+
+          // Update scroll offset to keep selection visible (max 3 visible items)
+          const MAX_VISIBLE: usize = 3;
+          if new_idx >= self.autocomplete_scroll_offset + MAX_VISIBLE {
+            self.autocomplete_scroll_offset = new_idx - MAX_VISIBLE + 1;
+          } else if new_idx < self.autocomplete_scroll_offset {
+            self.autocomplete_scroll_offset = new_idx;
+          }
+        }
+      }
+      KeyCode::Up => {
+        // Navigate up in autocomplete suggestions
+        if self.show_autocomplete && !self.filtered_packages.is_empty() {
+          let new_idx = match self.autocomplete_selected_index {
+            None => self.filtered_packages.len() - 1,
+            Some(idx) => {
+              if idx > 0 {
+                idx - 1
+              } else {
+                self.filtered_packages.len() - 1 // Wrap to bottom
+              }
+            }
+          };
+
+          self.autocomplete_selected_index = Some(new_idx);
+
+          // Update scroll offset to keep selection visible (max 3 visible items)
+          const MAX_VISIBLE: usize = 3;
+          if new_idx >= self.autocomplete_scroll_offset + MAX_VISIBLE {
+            self.autocomplete_scroll_offset = new_idx - MAX_VISIBLE + 1;
+          } else if new_idx < self.autocomplete_scroll_offset {
+            self.autocomplete_scroll_offset = new_idx;
+          }
+        }
+      }
+      KeyCode::Tab | KeyCode::Enter => {
+        // Accept autocomplete suggestion
+        if self.show_autocomplete && !self.filtered_packages.is_empty() {
+          if let Some(idx) = self.autocomplete_selected_index {
+            if let Some(selected) = self.filtered_packages.get(idx) {
+              self.package_name = selected.clone();
+              self.package_name_cursor = self.package_name.len();
+              self.show_autocomplete = false;
+              self.autocomplete_selected_index = None;
+              self.autocomplete_scroll_offset = 0;
+              self.filtered_packages.clear();
+            }
+          } else if !self.filtered_packages.is_empty() {
+            // If nothing selected, select first suggestion
+            self.package_name = self.filtered_packages[0].clone();
+            self.package_name_cursor = self.package_name.len();
+            self.show_autocomplete = false;
+            self.autocomplete_selected_index = None;
+            self.autocomplete_scroll_offset = 0;
+            self.filtered_packages.clear();
+          }
+        } else if key == KeyCode::Enter {
+          // If no autocomplete, Enter exits insert mode
+          self.state.input_mode = InputMode::Normal;
+        }
+      }
+      KeyCode::Esc => {
+        // Hide autocomplete without selecting
+        self.show_autocomplete = false;
+        self.autocomplete_selected_index = None;
+        self.autocomplete_scroll_offset = 0;
+      }
+      _ => {}
+    }
+  }
+
+  fn update_file_type_value(&mut self) {
+    if let Some(i) = self.file_type_state.selected() {
+      let variants = JavaFileType::value_variants();
+      if let Some(variant) = variants.get(i) {
+        self.file_type = variant.clone();
+      }
+    }
+  }
+
+  fn execute_create_java_file(&mut self) {
+    // Call service directly with enum types - always use Main source directory
+    match create_java_file_service::run(
+      &self.cwd,
+      &self.package_name,
+      &self.file_name,
+      &self.file_type,
+      &JavaSourceDirectoryType::Main,
+    ) {
+      Ok(response) => {
+        // Success! Print result to stderr (stdout reserved for TUI)
+        eprintln!("Successfully created {} at {}", response.file_type, response.file_path);
+        // Signal quit and exit with success code
+        self.state.should_quit = true;
+        std::process::exit(0);
+      }
+      Err(e) => {
+        // Show error in UI instead of quitting
+        self.state.error_message = Some(format!("Error: {}", e));
+      }
+    }
+  }
+
+  fn render_file_type_selector(&mut self, frame: &mut Frame, area: Rect) {
+    let is_focused = self.focused_field == FocusedField::FileType;
+    let variants = JavaFileType::value_variants();
+
+    let items: Vec<ListItem> = variants
+      .iter()
+      .enumerate()
+      .map(|(i, variant)| {
+        let is_selected = self.file_type_state.selected() == Some(i);
+        let prefix = if is_selected { "●" } else { "○" };
+
+        // Get display name from enum using to_possible_value()
+        let display_name = variant
+          .to_possible_value()
+          .map(|pv| pv.get_name().to_string())
+          .unwrap_or_else(|| "unknown".to_string());
+
+        // Capitalize first letter for display: "class" -> "Class"
+        let label = if !display_name.is_empty() {
+          format!("{}{}", display_name[0..1].to_uppercase(), &display_name[1..])
+        } else {
+          display_name
+        };
+
+        ListItem::new(format!(" {} {}", prefix, label))
+      })
+      .collect();
+
+    let border_style =
+      if is_focused { Style::default().fg(Color::Yellow) } else { Style::default() };
+    let title = self.generate_title("File type", is_focused);
+    let list = List::new(items)
+      .block(Block::default().title(title).borders(Borders::ALL).border_style(border_style))
+      .highlight_style(Style::default().bg(Color::DarkGray).add_modifier(Modifier::BOLD))
+      .highlight_symbol(">> ");
+
+    frame.render_stateful_widget(list, area, &mut self.file_type_state);
+  }
+
+  fn render_file_name_input(&mut self, frame: &mut Frame, area: Rect) {
+    let is_focused = self.focused_field == FocusedField::FileName;
+    let border_style =
+      if is_focused { Style::default().fg(Color::Yellow) } else { Style::default() };
+    let title = self.generate_title("File name", is_focused);
+    let input = Paragraph::new(self.file_name.as_str())
+      .block(Block::default().title(title).borders(Borders::ALL).border_style(border_style));
+    frame.render_widget(input, area);
+    if is_focused && self.state.input_mode == InputMode::Insert {
+      frame.set_cursor_position((area.x + self.file_name_cursor as u16 + 1, area.y + 1));
+    }
+  }
+
+  fn render_package_name_input(&mut self, frame: &mut Frame, area: Rect) {
+    let is_focused = self.focused_field == FocusedField::PackageName;
+    let border_style =
+      if is_focused { Style::default().fg(Color::Yellow) } else { Style::default() };
+
+    // Build title with autocomplete hint
+    let title = if is_focused && self.show_autocomplete && !self.filtered_packages.is_empty() {
+      format!(
+        "Package name [↑↓ navigate, Tab/Enter select, Esc cancel] ({} matches)",
+        self.filtered_packages.len()
+      )
+    } else {
+      self.generate_title("Package name", is_focused)
+    };
+
+    let input = Paragraph::new(self.package_name.as_str())
+      .block(Block::default().title(title).borders(Borders::ALL).border_style(border_style));
+    frame.render_widget(input, area);
+
+    if is_focused && self.state.input_mode == InputMode::Insert {
+      frame.set_cursor_position((area.x + self.package_name_cursor as u16 + 1, area.y + 1));
+    }
+  }
+
+  fn render_autocomplete_dropdown(&self, frame: &mut Frame, area: Rect) {
+    if !self.show_autocomplete || self.filtered_packages.is_empty() {
+      return;
+    }
+
+    const MAX_VISIBLE: usize = 3;
+    let total_items = self.filtered_packages.len();
+
+    // Calculate visible range
+    let visible_start = self.autocomplete_scroll_offset;
+    let visible_end = (visible_start + MAX_VISIBLE).min(total_items);
+
+    // Create list items for visible autocomplete suggestions only
+    let items: Vec<ListItem> = self
+      .filtered_packages
+      .iter()
+      .enumerate()
+      .skip(visible_start)
+      .take(visible_end - visible_start)
+      .map(|(i, pkg)| {
+        let is_selected = self.autocomplete_selected_index == Some(i);
+        let prefix = if is_selected { "▶" } else { " " };
+        ListItem::new(format!("{} {}", prefix, pkg)).style(if is_selected {
+          Style::default().bg(Color::DarkGray).fg(Color::White).add_modifier(Modifier::BOLD)
+        } else {
+          Style::default()
+        })
+      })
+      .collect();
+
+    // Build title with scroll indicator
+    let title = if total_items > MAX_VISIBLE {
+      format!("Suggestions ({}-{} of {})", visible_start + 1, visible_end, total_items)
+    } else {
+      format!("Suggestions ({})", total_items)
+    };
+
+    let list = List::new(items).block(
+      Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Cyan))
+        .title(title),
+    );
+
+    frame.render_widget(list, area);
+  }
+
+  fn render_confirm_button(&self, frame: &mut Frame, area: Rect) {
+    let is_focused = self.focused_field == FocusedField::ConfirmButton;
+    let color = match self.state.escape_handler.pressed_once {
+      true => Color::Red,
+      false => Color::Green,
+    };
+    let text = match self.state.escape_handler.pressed_once {
+      true => "Press esc again to close or any key to return",
+      false => "Confirm",
+    };
+    let style = if is_focused {
+      Style::default().bg(color).fg(Color::Black).add_modifier(Modifier::BOLD)
+    } else {
+      Style::default().fg(color)
+    };
+    let button = Paragraph::new(format!("[ {} ]", text).to_string())
+      .alignment(Alignment::Center)
+      .style(style)
+      .block(Block::default().borders(Borders::empty()));
+    frame.render_widget(button, area);
+  }
+
+  fn render_title_bar(&self, frame: &mut Frame, area: Rect) {
+    let title = Paragraph::new("Create new Java file")
+      .alignment(Alignment::Center)
+      .style(Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD))
+      .block(Block::default().borders(Borders::BOTTOM));
+    frame.render_widget(title, area);
+  }
+
+  pub fn render(&mut self, frame: &mut Frame) {
+    let area = frame.area();
+
+    // Split form into sections
+    let chunks = Layout::default()
+      .direction(Direction::Vertical)
+      .constraints([
+        Constraint::Length(2), // Title bar
+        Constraint::Length(6), // File type selector (4 types + 2 borders)
+        Constraint::Length(3), // File name input
+        Constraint::Length(3), // Package name input
+        Constraint::Min(3),    // Flexible space for autocomplete + errors
+        Constraint::Length(1), // Confirm button
+      ])
+      .split(area);
+
+    // Render combined title/status bar
+    self.render_title_bar(frame, chunks[0]);
+
+    // Render file type selector
+    self.render_file_type_selector(frame, chunks[1]);
+
+    // Render file name input
+    self.render_file_name_input(frame, chunks[2]);
+
+    // Render package name input
+    self.render_package_name_input(frame, chunks[3]);
+
+    // Render autocomplete dropdown and error message in flexible space
+    let flexible_area = chunks[4];
+
+    // Calculate autocomplete dropdown size (always 5 lines: 2 border + 3 items max)
+    let autocomplete_height = if self.show_autocomplete && !self.filtered_packages.is_empty() {
+      5 // Fixed height: 2 borders + 3 visible items
+    } else {
+      0
+    };
+
+    if autocomplete_height > 0 {
+      let autocomplete_chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Length(autocomplete_height), Constraint::Min(0)])
+        .split(flexible_area);
+
+      self.render_autocomplete_dropdown(frame, autocomplete_chunks[0]);
+
+      // Render error in remaining space
+      if let Some(ref error_msg) = self.state.error_message {
+        let error_paragraph =
+          Paragraph::new(error_msg.as_str()).style(Style::default().fg(Color::Red)).block(
+            Block::default()
+              .title("Error")
+              .borders(Borders::ALL)
+              .border_style(Style::default().fg(Color::Red)),
+          );
+        frame.render_widget(error_paragraph, autocomplete_chunks[1]);
+      }
+    } else {
+      // No autocomplete, just render error if present
+      if let Some(ref error_msg) = self.state.error_message {
+        let error_paragraph =
+          Paragraph::new(error_msg.as_str()).style(Style::default().fg(Color::Red)).block(
+            Block::default()
+              .title("Error")
+              .borders(Borders::ALL)
+              .border_style(Style::default().fg(Color::Red)),
+          );
+        frame.render_widget(error_paragraph, flexible_area);
+      }
+    }
+
+    // Render confirm button
+    self.render_confirm_button(frame, chunks[5]);
+  }
+}
+
+// Implement the FormBehavior trait to get inherited methods
+impl FormBehavior for CreateJavaFileForm {
+  fn form_state(&self) -> &FormState {
+    &self.state
+  }
+
+  fn form_state_mut(&mut self) -> &mut FormState {
+    &mut self.state
+  }
+
+  fn focus_next(&mut self) {
+    CreateJavaFileForm::focus_next(self)
+  }
+
+  fn focus_prev(&mut self) {
+    CreateJavaFileForm::focus_prev(self)
+  }
+
+  fn on_enter_insert_mode(&mut self, key: KeyCode) {
+    CreateJavaFileForm::on_enter_insert_mode(self, key)
+  }
+
+  fn on_enter_pressed(&mut self) {
+    CreateJavaFileForm::on_enter_pressed(self)
+  }
+
+  fn handle_field_insert(&mut self, key: KeyCode) {
+    CreateJavaFileForm::handle_field_insert(self, key)
+  }
+
+  fn render(&mut self, frame: &mut Frame) {
+    CreateJavaFileForm::render(self, frame)
+  }
+}

--- a/src/ui/forms/create_jpa_entity.rs
+++ b/src/ui/forms/create_jpa_entity.rs
@@ -1,0 +1,674 @@
+use crossterm::event::KeyCode;
+use ratatui::{
+  Frame,
+  layout::{Alignment, Constraint, Direction, Layout, Rect},
+  style::{Color, Modifier, Style},
+  widgets::{Block, Borders, List, ListItem, ListState, Paragraph},
+};
+use std::path::{Path, PathBuf};
+
+use crate::commands::services::create_jpa_entity_service;
+use crate::commands::{get_all_jpa_mapped_superclasses, get_all_packages_command};
+use crate::common::types::java_source_directory_type::JavaSourceDirectoryType;
+use crate::ui::form_trait::{FormBehavior, FormState, InputMode, helpers};
+
+/// Represents which field is currently focused
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum FocusedField {
+  EntityName,
+  Superclass,
+  PackageName,
+  ConfirmButton,
+}
+
+/// Main form state for creating a JPA entity
+pub struct CreateJpaEntityForm {
+  // Common form state (embedded)
+  state: FormState,
+
+  // Field values
+  entity_name: String,
+  package_name: String,
+  selected_superclass_index: Option<usize>, // None means no superclass (first item)
+
+  // Package autocomplete
+  package_list: Vec<String>,
+  filtered_packages: Vec<String>,
+  package_autocomplete_selected_index: Option<usize>,
+  package_autocomplete_scroll_offset: usize,
+  show_package_autocomplete: bool,
+
+  // Superclass selection (list)
+  superclass_list: Vec<String>, // All available mapped superclasses
+  superclass_state: ListState,
+
+  // Text input states
+  entity_name_cursor: usize,
+  package_name_cursor: usize,
+
+  // Focus management
+  focused_field: FocusedField,
+
+  // Integration with syntaxpresso-core
+  cwd: PathBuf,
+}
+
+impl CreateJpaEntityForm {
+  pub fn new(cwd: PathBuf) -> Self {
+    // Fetch packages from syntaxpresso-core
+    let package_list = Self::fetch_packages(&cwd).unwrap_or_else(|_| {
+      vec![
+        "com.example".to_string(),
+        "com.example.model".to_string(),
+        "com.example.entity".to_string(),
+      ]
+    });
+
+    // Fetch mapped superclasses from syntaxpresso-core
+    let mut superclass_list = Self::fetch_superclasses(&cwd).unwrap_or_else(|_| vec![]);
+
+    // Add "None" as the first option
+    superclass_list.insert(0, "None".to_string());
+
+    let default_package =
+      package_list.first().cloned().unwrap_or_else(|| "com.example".to_string());
+
+    let mut superclass_state = ListState::default();
+    superclass_state.select(Some(0)); // Default to "None"
+
+    Self {
+      state: FormState::new(),
+      entity_name: "NewEntity".to_string(),
+      package_name: default_package.clone(),
+      selected_superclass_index: Some(0), // Default to "None"
+      package_list,
+      filtered_packages: Vec::new(),
+      package_autocomplete_selected_index: None,
+      package_autocomplete_scroll_offset: 0,
+      show_package_autocomplete: false,
+      superclass_list,
+      superclass_state,
+      entity_name_cursor: 9, // Position at end of "NewEntity"
+      package_name_cursor: default_package.len(),
+      focused_field: FocusedField::EntityName,
+      cwd,
+    }
+  }
+
+  /// Fetch packages from syntaxpresso-core using the get-all-packages command
+  fn fetch_packages(cwd: &Path) -> Result<Vec<String>, Box<dyn std::error::Error>> {
+    let response = get_all_packages_command::execute(cwd, &JavaSourceDirectoryType::Main);
+
+    let mut packages = Vec::new();
+    if let Some(data) = response.data {
+      for pkg in data.packages {
+        packages.push(pkg.package_name);
+      }
+    }
+
+    Ok(packages)
+  }
+
+  /// Fetch mapped superclasses from syntaxpresso-core
+  fn fetch_superclasses(cwd: &Path) -> Result<Vec<String>, Box<dyn std::error::Error>> {
+    let response = get_all_jpa_mapped_superclasses::execute(cwd);
+
+    let mut superclasses = Vec::new();
+    if let Some(data) = response.data {
+      for file in data.files {
+        superclasses.push(file.file_type);
+      }
+    }
+
+    Ok(superclasses)
+  }
+
+  /// Move focus to the next field
+  fn focus_next(&mut self) {
+    self.focused_field = match self.focused_field {
+      FocusedField::EntityName => FocusedField::Superclass,
+      FocusedField::Superclass => FocusedField::PackageName,
+      FocusedField::PackageName => FocusedField::ConfirmButton,
+      FocusedField::ConfirmButton => FocusedField::EntityName,
+    };
+  }
+
+  /// Move focus to the previous field
+  fn focus_prev(&mut self) {
+    self.focused_field = match self.focused_field {
+      FocusedField::EntityName => FocusedField::ConfirmButton,
+      FocusedField::Superclass => FocusedField::EntityName,
+      FocusedField::PackageName => FocusedField::Superclass,
+      FocusedField::ConfirmButton => FocusedField::PackageName,
+    };
+  }
+
+  /// Filter packages based on current input (for autocomplete)
+  fn filter_packages(&mut self) {
+    if self.package_name.is_empty() {
+      self.filtered_packages.clear();
+      self.show_package_autocomplete = false;
+      self.package_autocomplete_scroll_offset = 0;
+      return;
+    }
+
+    let input_lower = self.package_name.to_lowercase();
+
+    let mut prefix_matches = Vec::new();
+    let mut contains_matches = Vec::new();
+
+    for package in &self.package_list {
+      let package_lower = package.to_lowercase();
+      if package_lower.starts_with(&input_lower) {
+        prefix_matches.push(package.clone());
+      } else if package_lower.contains(&input_lower) {
+        contains_matches.push(package.clone());
+      }
+    }
+
+    prefix_matches.sort();
+    contains_matches.sort();
+    prefix_matches.extend(contains_matches);
+
+    self.filtered_packages = prefix_matches.into_iter().take(7).collect();
+    self.show_package_autocomplete = !self.filtered_packages.is_empty();
+
+    if let Some(idx) = self.package_autocomplete_selected_index && idx >= self.filtered_packages.len() {
+      self.package_autocomplete_selected_index = None;
+      self.package_autocomplete_scroll_offset = 0;
+    }
+  }
+
+  /// Update the selected superclass index from the list state
+  fn update_superclass_value(&mut self) {
+    self.selected_superclass_index = self.superclass_state.selected();
+  }
+
+  /// Called when entering insert mode - 'a' moves cursor to end for text inputs
+  fn on_enter_insert_mode(&mut self, key: KeyCode) {
+    if key == KeyCode::Char('a') {
+      match self.focused_field {
+        FocusedField::EntityName => {
+          self.entity_name_cursor = self.entity_name.len();
+        }
+        FocusedField::PackageName => {
+          self.package_name_cursor = self.package_name.len();
+        }
+        _ => {}
+      }
+    }
+  }
+
+  /// Called when Enter is pressed in Normal mode
+  fn on_enter_pressed(&mut self) {
+    if self.focused_field == FocusedField::ConfirmButton {
+      self.execute_create_jpa_entity();
+    }
+  }
+
+  /// Handle field-specific input in Insert mode
+  fn handle_field_insert(&mut self, key: KeyCode) {
+    match self.focused_field {
+      FocusedField::EntityName => self.handle_entity_name_input(key),
+      FocusedField::Superclass => self.handle_superclass_insert(key),
+      FocusedField::PackageName => self.handle_package_name_input(key),
+      FocusedField::ConfirmButton => {
+        self.state.input_mode = InputMode::Normal;
+      }
+    }
+  }
+
+  fn handle_superclass_insert(&mut self, key: KeyCode) {
+    match key {
+      KeyCode::Char('j') | KeyCode::Down => {
+        let len = self.superclass_list.len();
+        helpers::navigate_list_static(&KeyCode::Down, &mut self.superclass_state, len);
+        self.update_superclass_value();
+      }
+      KeyCode::Char('k') | KeyCode::Up => {
+        let len = self.superclass_list.len();
+        helpers::navigate_list_static(&KeyCode::Up, &mut self.superclass_state, len);
+        self.update_superclass_value();
+      }
+      KeyCode::Enter => {
+        self.state.input_mode = InputMode::Normal;
+      }
+      _ => {}
+    }
+  }
+
+  fn handle_entity_name_input(&mut self, key: KeyCode) {
+    match key {
+      KeyCode::Char(c) => {
+        self.entity_name.insert(self.entity_name_cursor, c);
+        self.entity_name_cursor += 1;
+      }
+      KeyCode::Backspace => {
+        if self.entity_name_cursor > 0 {
+          self.entity_name.remove(self.entity_name_cursor - 1);
+          self.entity_name_cursor -= 1;
+        }
+      }
+      KeyCode::Delete => {
+        if self.entity_name_cursor < self.entity_name.len() {
+          self.entity_name.remove(self.entity_name_cursor);
+        }
+      }
+      KeyCode::Left => {
+        if self.entity_name_cursor > 0 {
+          self.entity_name_cursor -= 1;
+        }
+      }
+      KeyCode::Right => {
+        if self.entity_name_cursor < self.entity_name.len() {
+          self.entity_name_cursor += 1;
+        }
+      }
+      KeyCode::Home => {
+        self.entity_name_cursor = 0;
+      }
+      KeyCode::End => {
+        self.entity_name_cursor = self.entity_name.len();
+      }
+      _ => {}
+    }
+  }
+
+  fn handle_package_name_input(&mut self, key: KeyCode) {
+    match key {
+      KeyCode::Char(c) => {
+        self.package_name.insert(self.package_name_cursor, c);
+        self.package_name_cursor += 1;
+        self.filter_packages();
+        self.package_autocomplete_selected_index = None;
+        self.package_autocomplete_scroll_offset = 0;
+      }
+      KeyCode::Backspace => {
+        if self.package_name_cursor > 0 {
+          self.package_name.remove(self.package_name_cursor - 1);
+          self.package_name_cursor -= 1;
+          self.filter_packages();
+          self.package_autocomplete_selected_index = None;
+          self.package_autocomplete_scroll_offset = 0;
+        }
+      }
+      KeyCode::Delete => {
+        if self.package_name_cursor < self.package_name.len() {
+          self.package_name.remove(self.package_name_cursor);
+          self.filter_packages();
+          self.package_autocomplete_selected_index = None;
+          self.package_autocomplete_scroll_offset = 0;
+        }
+      }
+      KeyCode::Left => {
+        if self.package_name_cursor > 0 {
+          self.package_name_cursor -= 1;
+        }
+      }
+      KeyCode::Right => {
+        if self.package_name_cursor < self.package_name.len() {
+          self.package_name_cursor += 1;
+        }
+      }
+      KeyCode::Home => {
+        self.package_name_cursor = 0;
+      }
+      KeyCode::End => {
+        self.package_name_cursor = self.package_name.len();
+      }
+      KeyCode::Down => {
+        if self.show_package_autocomplete && !self.filtered_packages.is_empty() {
+          let new_idx = match self.package_autocomplete_selected_index {
+            None => 0,
+            Some(idx) => {
+              if idx + 1 < self.filtered_packages.len() {
+                idx + 1
+              } else {
+                0
+              }
+            }
+          };
+
+          self.package_autocomplete_selected_index = Some(new_idx);
+
+          const MAX_VISIBLE: usize = 3;
+          if new_idx >= self.package_autocomplete_scroll_offset + MAX_VISIBLE {
+            self.package_autocomplete_scroll_offset = new_idx - MAX_VISIBLE + 1;
+          } else if new_idx < self.package_autocomplete_scroll_offset {
+            self.package_autocomplete_scroll_offset = new_idx;
+          }
+        }
+      }
+      KeyCode::Up => {
+        if self.show_package_autocomplete && !self.filtered_packages.is_empty() {
+          let new_idx = match self.package_autocomplete_selected_index {
+            None => self.filtered_packages.len() - 1,
+            Some(idx) => {
+              if idx > 0 {
+                idx - 1
+              } else {
+                self.filtered_packages.len() - 1
+              }
+            }
+          };
+
+          self.package_autocomplete_selected_index = Some(new_idx);
+
+          const MAX_VISIBLE: usize = 3;
+          if new_idx >= self.package_autocomplete_scroll_offset + MAX_VISIBLE {
+            self.package_autocomplete_scroll_offset = new_idx - MAX_VISIBLE + 1;
+          } else if new_idx < self.package_autocomplete_scroll_offset {
+            self.package_autocomplete_scroll_offset = new_idx;
+          }
+        }
+      }
+      KeyCode::Tab | KeyCode::Enter => {
+        if self.show_package_autocomplete && !self.filtered_packages.is_empty() {
+          if let Some(idx) = self.package_autocomplete_selected_index {
+            if let Some(selected) = self.filtered_packages.get(idx) {
+              self.package_name = selected.clone();
+              self.package_name_cursor = self.package_name.len();
+              self.show_package_autocomplete = false;
+              self.package_autocomplete_selected_index = None;
+              self.package_autocomplete_scroll_offset = 0;
+              self.filtered_packages.clear();
+            }
+          } else if !self.filtered_packages.is_empty() {
+            self.package_name = self.filtered_packages[0].clone();
+            self.package_name_cursor = self.package_name.len();
+            self.show_package_autocomplete = false;
+            self.package_autocomplete_selected_index = None;
+            self.package_autocomplete_scroll_offset = 0;
+            self.filtered_packages.clear();
+          }
+        } else if key == KeyCode::Enter {
+          self.state.input_mode = InputMode::Normal;
+        }
+      }
+      KeyCode::Esc => {
+        self.show_package_autocomplete = false;
+        self.package_autocomplete_selected_index = None;
+        self.package_autocomplete_scroll_offset = 0;
+      }
+      _ => {}
+    }
+  }
+
+  fn execute_create_jpa_entity(&mut self) {
+    // Get superclass if one is selected (index 0 is "None")
+    let (superclass_type, superclass_package_name) =
+      if let Some(idx) = self.selected_superclass_index {
+        if idx > 0 && idx < self.superclass_list.len() {
+          // Selected a real superclass (not "None")
+          let superclass = &self.superclass_list[idx];
+          // For now, we'll assume the superclass is in the same package
+          // In a more sophisticated implementation, you'd fetch the actual package
+          (Some(superclass.as_str()), Some(self.package_name.as_str()))
+        } else {
+          // Selected "None"
+          (None, None)
+        }
+      } else {
+        (None, None)
+      };
+
+    match create_jpa_entity_service::run(
+      &self.cwd,
+      &self.package_name,
+      &self.entity_name,
+      superclass_type,
+      superclass_package_name,
+    ) {
+      Ok(response) => {
+        eprintln!(
+          "Successfully created JPA Entity {} at {}",
+          response.file_type, response.file_path
+        );
+        self.state.should_quit = true;
+        std::process::exit(0);
+      }
+      Err(e) => {
+        self.state.error_message = Some(format!("Error: {}", e));
+      }
+    }
+  }
+
+  fn render_entity_name_input(&mut self, frame: &mut Frame, area: Rect) {
+    let is_focused = self.focused_field == FocusedField::EntityName;
+    let border_style =
+      if is_focused { Style::default().fg(Color::Yellow) } else { Style::default() };
+    let title = self.generate_title("Entity name", is_focused);
+    let input = Paragraph::new(self.entity_name.as_str())
+      .block(Block::default().title(title).borders(Borders::ALL).border_style(border_style));
+    frame.render_widget(input, area);
+    if is_focused && self.state.input_mode == InputMode::Insert {
+      frame.set_cursor_position((area.x + self.entity_name_cursor as u16 + 1, area.y + 1));
+    }
+  }
+
+  fn render_package_name_input(&mut self, frame: &mut Frame, area: Rect) {
+    let is_focused = self.focused_field == FocusedField::PackageName;
+    let border_style =
+      if is_focused { Style::default().fg(Color::Yellow) } else { Style::default() };
+
+    let title =
+      if is_focused && self.show_package_autocomplete && !self.filtered_packages.is_empty() {
+        format!(
+          "Package name [↑↓ navigate, Tab/Enter select, Esc cancel] ({} matches)",
+          self.filtered_packages.len()
+        )
+      } else {
+        self.generate_title("Package name", is_focused)
+      };
+
+    let input = Paragraph::new(self.package_name.as_str())
+      .block(Block::default().title(title).borders(Borders::ALL).border_style(border_style));
+    frame.render_widget(input, area);
+
+    if is_focused && self.state.input_mode == InputMode::Insert {
+      frame.set_cursor_position((area.x + self.package_name_cursor as u16 + 1, area.y + 1));
+    }
+  }
+
+  fn render_superclass_selector(&mut self, frame: &mut Frame, area: Rect) {
+    let is_focused = self.focused_field == FocusedField::Superclass;
+
+    let items: Vec<ListItem> = self
+      .superclass_list
+      .iter()
+      .enumerate()
+      .map(|(i, superclass)| {
+        let is_selected = self.superclass_state.selected() == Some(i);
+        let prefix = if is_selected { "●" } else { "○" };
+        ListItem::new(format!(" {} {}", prefix, superclass))
+      })
+      .collect();
+
+    let border_style =
+      if is_focused { Style::default().fg(Color::Yellow) } else { Style::default() };
+
+    let title = self.generate_title("Superclass (optional)", is_focused);
+    let list = List::new(items)
+      .block(Block::default().title(title).borders(Borders::ALL).border_style(border_style))
+      .highlight_style(Style::default().bg(Color::DarkGray).add_modifier(Modifier::BOLD))
+      .highlight_symbol(">> ");
+
+    frame.render_stateful_widget(list, area, &mut self.superclass_state);
+  }
+
+  fn render_autocomplete_dropdown(&self, frame: &mut Frame, area: Rect) {
+    if !self.show_package_autocomplete || self.filtered_packages.is_empty() {
+      return;
+    }
+
+    const MAX_VISIBLE: usize = 3;
+    let total_items = self.filtered_packages.len();
+
+    let visible_start = self.package_autocomplete_scroll_offset;
+    let visible_end = (visible_start + MAX_VISIBLE).min(total_items);
+
+    let list_items: Vec<ListItem> = self
+      .filtered_packages
+      .iter()
+      .enumerate()
+      .skip(visible_start)
+      .take(visible_end - visible_start)
+      .map(|(i, item)| {
+        let is_selected = self.package_autocomplete_selected_index == Some(i);
+        let prefix = if is_selected { "▶" } else { " " };
+        ListItem::new(format!("{} {}", prefix, item)).style(if is_selected {
+          Style::default().bg(Color::DarkGray).fg(Color::White).add_modifier(Modifier::BOLD)
+        } else {
+          Style::default()
+        })
+      })
+      .collect();
+
+    let title = if total_items > MAX_VISIBLE {
+      format!("Suggestions ({}-{} of {})", visible_start + 1, visible_end, total_items)
+    } else {
+      format!("Suggestions ({})", total_items)
+    };
+
+    let list = List::new(list_items).block(
+      Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Cyan))
+        .title(title),
+    );
+
+    frame.render_widget(list, area);
+  }
+
+  fn render_confirm_button(&self, frame: &mut Frame, area: Rect) {
+    let is_focused = self.focused_field == FocusedField::ConfirmButton;
+    let color = match self.state.escape_handler.pressed_once {
+      true => Color::Red,
+      false => Color::Green,
+    };
+    let text = match self.state.escape_handler.pressed_once {
+      true => "Press esc again to close or any key to return",
+      false => "Confirm",
+    };
+    let style = if is_focused {
+      Style::default().bg(color).fg(Color::Black).add_modifier(Modifier::BOLD)
+    } else {
+      Style::default().fg(color)
+    };
+    let button = Paragraph::new(format!("[ {} ]", text))
+      .alignment(Alignment::Center)
+      .style(style)
+      .block(Block::default().borders(Borders::empty()));
+    frame.render_widget(button, area);
+  }
+
+  fn render_title_bar(&self, frame: &mut Frame, area: Rect) {
+    let title = Paragraph::new("Create new JPA Entity")
+      .alignment(Alignment::Center)
+      .style(Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD))
+      .block(Block::default().borders(Borders::BOTTOM));
+    frame.render_widget(title, area);
+  }
+
+  pub fn render(&mut self, frame: &mut Frame) {
+    let area = frame.area();
+
+    // Calculate superclass list height dynamically
+    // Max 6 lines total (2 borders + 4 items visible)
+    // This allows scrolling if there are more than 4 items
+    let superclass_height = (self.superclass_list.len() as u16 + 2).min(6);
+
+    let chunks = Layout::default()
+      .direction(Direction::Vertical)
+      .constraints([
+        Constraint::Length(2),                 // Title bar
+        Constraint::Length(3),                 // Entity name input
+        Constraint::Length(superclass_height), // Superclass selector (dynamic, max 6)
+        Constraint::Length(3),                 // Package name input
+        Constraint::Min(3),                    // Flexible space for autocomplete + errors
+        Constraint::Length(1),                 // Confirm button
+      ])
+      .split(area);
+
+    self.render_title_bar(frame, chunks[0]);
+    self.render_entity_name_input(frame, chunks[1]);
+    self.render_superclass_selector(frame, chunks[2]);
+    self.render_package_name_input(frame, chunks[3]);
+
+    // Render autocomplete dropdown and error message in flexible space
+    let flexible_area = chunks[4];
+
+    // Only show autocomplete for package name
+    let show_autocomplete = self.focused_field == FocusedField::PackageName
+      && self.show_package_autocomplete
+      && !self.filtered_packages.is_empty();
+
+    let autocomplete_height = if show_autocomplete { 5 } else { 0 };
+
+    if autocomplete_height > 0 {
+      let autocomplete_chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Length(autocomplete_height), Constraint::Min(0)])
+        .split(flexible_area);
+
+      self.render_autocomplete_dropdown(frame, autocomplete_chunks[0]);
+
+      if let Some(ref error_msg) = self.state.error_message {
+        let error_paragraph =
+          Paragraph::new(error_msg.as_str()).style(Style::default().fg(Color::Red)).block(
+            Block::default()
+              .title("Error")
+              .borders(Borders::ALL)
+              .border_style(Style::default().fg(Color::Red)),
+          );
+        frame.render_widget(error_paragraph, autocomplete_chunks[1]);
+      }
+    } else if let Some(ref error_msg) = self.state.error_message {
+      let error_paragraph =
+        Paragraph::new(error_msg.as_str()).style(Style::default().fg(Color::Red)).block(
+          Block::default()
+            .title("Error")
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(Color::Red)),
+        );
+      frame.render_widget(error_paragraph, flexible_area);
+    }
+
+    self.render_confirm_button(frame, chunks[5]);
+  }
+}
+
+// Implement the FormBehavior trait to get inherited methods
+impl FormBehavior for CreateJpaEntityForm {
+  fn form_state(&self) -> &FormState {
+    &self.state
+  }
+
+  fn form_state_mut(&mut self) -> &mut FormState {
+    &mut self.state
+  }
+
+  fn focus_next(&mut self) {
+    CreateJpaEntityForm::focus_next(self)
+  }
+
+  fn focus_prev(&mut self) {
+    CreateJpaEntityForm::focus_prev(self)
+  }
+
+  fn on_enter_insert_mode(&mut self, key: KeyCode) {
+    CreateJpaEntityForm::on_enter_insert_mode(self, key)
+  }
+
+  fn on_enter_pressed(&mut self) {
+    CreateJpaEntityForm::on_enter_pressed(self)
+  }
+
+  fn handle_field_insert(&mut self, key: KeyCode) {
+    CreateJpaEntityForm::handle_field_insert(self, key)
+  }
+
+  fn render(&mut self, frame: &mut Frame) {
+    CreateJpaEntityForm::render(self, frame)
+  }
+}

--- a/src/ui/forms/create_jpa_repository.rs
+++ b/src/ui/forms/create_jpa_repository.rs
@@ -1,0 +1,717 @@
+use crossterm::event::KeyCode;
+use ratatui::{
+  Frame,
+  layout::{Alignment, Constraint, Direction, Layout, Rect},
+  style::{Color, Modifier, Style},
+  widgets::{Block, Borders, List, ListItem, ListState, Paragraph, Wrap},
+};
+use std::path::{Path, PathBuf};
+
+use crate::commands::services::get_jpa_entity_info_service;
+use crate::commands::{
+  create_jpa_repository_command, get_all_packages_command, get_java_basic_types_command,
+};
+use crate::common::types::java_basic_types::JavaBasicType;
+use crate::common::types::java_source_directory_type::JavaSourceDirectoryType;
+use crate::ui::form_trait::{FormBehavior, FormState, InputMode, helpers};
+
+/// Represents which field is currently focused
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum FocusedField {
+  IdFieldType,
+  PackageName,
+  ConfirmButton,
+}
+
+/// Stores information about a Java type (for ID field selection)
+#[derive(Debug, Clone)]
+struct JavaTypeInfo {
+  name: String,
+  package_path: String,
+}
+
+/// Main form state for creating a JPA repository
+pub struct CreateJpaRepositoryForm {
+  // Common form state (embedded)
+  state: FormState,
+
+  // Entity information (provided at initialization)
+  cwd: PathBuf,
+  entity_file_path: PathBuf,
+  entity_file_b64_src: String,
+
+  // Available ID types from get-java-basic-types
+  available_id_types: Vec<JavaTypeInfo>,
+  id_type_state: ListState,
+  selected_id_type_index: Option<usize>,
+
+  // Package autocomplete
+  package_list: Vec<String>,
+  filtered_packages: Vec<String>,
+  package_autocomplete_selected_index: Option<usize>,
+  package_autocomplete_scroll_offset: usize,
+  show_package_autocomplete: bool,
+
+  // Field values
+  id_field_type: String,    // The selected/detected ID type name (e.g., "Long")
+  id_field_package: String, // The package path (e.g., "java.lang")
+  package_name: String,     // Repository package name
+
+  // Text input states
+  package_name_cursor: usize,
+
+  // Focus management
+  focused_field: FocusedField,
+
+  // Auto-detection status
+  auto_detected_id: bool,
+  entity_name: String,
+}
+
+impl CreateJpaRepositoryForm {
+  pub fn new(cwd: PathBuf, entity_file_b64_src: String, entity_file_path: PathBuf) -> Self {
+    // Fetch available ID types
+    let available_id_types = Self::fetch_id_types().unwrap_or_else(|_| {
+      vec![
+        JavaTypeInfo { name: "Long".to_string(), package_path: "java.lang".to_string() },
+        JavaTypeInfo { name: "Integer".to_string(), package_path: "java.lang".to_string() },
+        JavaTypeInfo { name: "String".to_string(), package_path: "java.lang".to_string() },
+        JavaTypeInfo { name: "UUID".to_string(), package_path: "java.util".to_string() },
+      ]
+    });
+
+    // Fetch packages for autocomplete
+    let package_list = Self::fetch_packages(&cwd).unwrap_or_else(|_| {
+      vec![
+        "com.example".to_string(),
+        "com.example.repository".to_string(),
+        "com.example.model.repository".to_string(),
+      ]
+    });
+
+    // Extract entity name from file path
+    let entity_name =
+      entity_file_path.file_stem().and_then(|s| s.to_str()).unwrap_or("Entity").to_string();
+
+    // Try to detect ID field from entity
+    let (id_field_type, id_field_package, auto_detected) =
+      Self::try_detect_id_field(&entity_file_path, &entity_file_b64_src, &available_id_types);
+
+    // Set default repository package (same as entity package)
+    let entity_package = Self::extract_entity_package(&entity_file_path);
+    let default_repo_package =
+      if entity_package.is_empty() { "com.example".to_string() } else { entity_package.clone() };
+
+    // Find the index of the detected/default ID type in the list
+    let mut id_type_state = ListState::default();
+    let selected_id_type_index = available_id_types
+      .iter()
+      .position(|t| t.name == id_field_type && t.package_path == id_field_package)
+      .or(Some(0)); // Default to first if not found
+
+    if let Some(idx) = selected_id_type_index {
+      id_type_state.select(Some(idx));
+    }
+
+    Self {
+      state: FormState::new(),
+      cwd,
+      entity_file_path,
+      entity_file_b64_src,
+      available_id_types,
+      id_type_state,
+      selected_id_type_index,
+      package_list,
+      filtered_packages: Vec::new(),
+      package_autocomplete_selected_index: None,
+      package_autocomplete_scroll_offset: 0,
+      show_package_autocomplete: false,
+      id_field_type,
+      id_field_package,
+      package_name: default_repo_package.clone(),
+      package_name_cursor: default_repo_package.len(),
+      focused_field: FocusedField::IdFieldType,
+      auto_detected_id: auto_detected,
+      entity_name,
+    }
+  }
+
+  /// Fetch available ID types from get-java-basic-types command
+  fn fetch_id_types() -> Result<Vec<JavaTypeInfo>, Box<dyn std::error::Error>> {
+    let response = get_java_basic_types_command::execute(&JavaBasicType::IdTypes);
+
+    let mut types = Vec::new();
+    if let Some(data) = response.data {
+      for type_info in data {
+        types.push(JavaTypeInfo {
+          name: type_info.name,
+          package_path: type_info.package_path.unwrap_or_else(|| "java.lang".to_string()),
+        });
+      }
+    }
+
+    Ok(types)
+  }
+
+  /// Fetch packages for autocomplete from get-all-packages command
+  fn fetch_packages(cwd: &Path) -> Result<Vec<String>, Box<dyn std::error::Error>> {
+    let response = get_all_packages_command::execute(cwd, &JavaSourceDirectoryType::Main);
+
+    if let Some(data) = response.data {
+      Ok(data.packages.iter().map(|p| p.package_name.clone()).collect())
+    } else {
+      Err("Failed to fetch packages".into())
+    }
+  }
+
+  /// Try to detect ID field from entity using get_jpa_entity_info_service
+  fn try_detect_id_field(
+    entity_file_path: &Path,
+    entity_file_b64_src: &str,
+    available_types: &[JavaTypeInfo],
+  ) -> (String, String, bool) {
+    // Try to get entity info
+    let entity_info_result =
+      get_jpa_entity_info_service::run(Some(entity_file_path), Some(entity_file_b64_src));
+
+    if let Ok(entity_info) = entity_info_result
+      && let (Some(id_type), Some(id_package)) =
+        (entity_info.id_field_type, entity_info.id_field_package_name)
+    {
+      return (id_type, id_package, true);
+    }
+
+    // Fallback: default to Long
+    (
+      available_types.first().map(|t| t.name.clone()).unwrap_or_else(|| "Long".to_string()),
+      available_types
+        .first()
+        .map(|t| t.package_path.clone())
+        .unwrap_or_else(|| "java.lang".to_string()),
+      false,
+    )
+  }
+
+  /// Extract entity package from file path
+  fn extract_entity_package(entity_file_path: &Path) -> String {
+    // Try to extract package from path like: .../src/main/java/com/example/demo/Entity.java
+    let path_str = entity_file_path.to_string_lossy();
+
+    if let Some(java_idx) = path_str.find("/src/main/java/") {
+      let after_java = &path_str[java_idx + 15..]; // Skip "/src/main/java/"
+      if let Some(last_slash) = after_java.rfind('/') {
+        let package_path = &after_java[..last_slash];
+        return package_path.replace('/', ".");
+      }
+    }
+
+    String::new()
+  }
+
+  /// Update selected ID type from list state
+  fn update_id_type_from_selection(&mut self) {
+    if let Some(idx) = self.id_type_state.selected()
+      && let Some(type_info) = self.available_id_types.get(idx)
+    {
+      self.id_field_type = type_info.name.clone();
+      self.id_field_package = type_info.package_path.clone();
+      self.selected_id_type_index = Some(idx);
+    }
+  }
+
+  /// Move focus to the next field
+  fn focus_next(&mut self) {
+    self.focused_field = match self.focused_field {
+      FocusedField::IdFieldType => FocusedField::PackageName,
+      FocusedField::PackageName => FocusedField::ConfirmButton,
+      FocusedField::ConfirmButton => FocusedField::IdFieldType,
+    };
+  }
+
+  /// Move focus to the previous field
+  fn focus_prev(&mut self) {
+    self.focused_field = match self.focused_field {
+      FocusedField::IdFieldType => FocusedField::ConfirmButton,
+      FocusedField::PackageName => FocusedField::IdFieldType,
+      FocusedField::ConfirmButton => FocusedField::PackageName,
+    };
+  }
+
+  /// Filter packages based on current input (for autocomplete)
+  fn filter_packages(&mut self) {
+    if self.package_name.is_empty() {
+      self.filtered_packages.clear();
+      self.show_package_autocomplete = false;
+      self.package_autocomplete_scroll_offset = 0;
+      return;
+    }
+
+    let input_lower = self.package_name.to_lowercase();
+
+    let mut prefix_matches = Vec::new();
+    let mut contains_matches = Vec::new();
+
+    for package in &self.package_list {
+      let package_lower = package.to_lowercase();
+      if package_lower.starts_with(&input_lower) {
+        prefix_matches.push(package.clone());
+      } else if package_lower.contains(&input_lower) {
+        contains_matches.push(package.clone());
+      }
+    }
+
+    prefix_matches.sort();
+    contains_matches.sort();
+    prefix_matches.extend(contains_matches);
+
+    self.filtered_packages = prefix_matches.into_iter().take(7).collect();
+    self.show_package_autocomplete = !self.filtered_packages.is_empty();
+
+    if let Some(idx) = self.package_autocomplete_selected_index
+      && idx >= self.filtered_packages.len()
+    {
+      self.package_autocomplete_selected_index = None;
+      self.package_autocomplete_scroll_offset = 0;
+    }
+  }
+
+  /// Called when entering insert mode - 'a' moves cursor to end for text inputs
+  fn on_enter_insert_mode(&mut self, key: KeyCode) {
+    if key == KeyCode::Char('a') && self.focused_field == FocusedField::PackageName {
+      self.package_name_cursor = self.package_name.len();
+    }
+  }
+
+  /// Called when Enter is pressed in Normal mode
+  fn on_enter_pressed(&mut self) {
+    if self.focused_field == FocusedField::ConfirmButton {
+      self.execute_create_jpa_repository();
+    }
+  }
+
+  /// Handle field-specific input in Insert mode
+  fn handle_field_insert(&mut self, key: KeyCode) {
+    match self.focused_field {
+      FocusedField::IdFieldType => self.handle_id_type_selector_insert(key),
+      FocusedField::PackageName => self.handle_package_name_input(key),
+      FocusedField::ConfirmButton => {
+        self.state.input_mode = InputMode::Normal;
+      }
+    }
+  }
+
+  fn handle_id_type_selector_insert(&mut self, key: KeyCode) {
+    match key {
+      KeyCode::Char('j') | KeyCode::Down => {
+        let len = self.available_id_types.len();
+        helpers::navigate_list_static(&KeyCode::Down, &mut self.id_type_state, len);
+        self.update_id_type_from_selection();
+      }
+      KeyCode::Char('k') | KeyCode::Up => {
+        let len = self.available_id_types.len();
+        helpers::navigate_list_static(&KeyCode::Up, &mut self.id_type_state, len);
+        self.update_id_type_from_selection();
+      }
+      KeyCode::Enter => {
+        self.state.input_mode = InputMode::Normal;
+      }
+      _ => {}
+    }
+  }
+
+  fn handle_package_name_input(&mut self, key: KeyCode) {
+    match key {
+      KeyCode::Char(c) => {
+        self.package_name.insert(self.package_name_cursor, c);
+        self.package_name_cursor += 1;
+        self.filter_packages();
+        self.package_autocomplete_selected_index = None;
+        self.package_autocomplete_scroll_offset = 0;
+      }
+      KeyCode::Backspace => {
+        if self.package_name_cursor > 0 {
+          self.package_name.remove(self.package_name_cursor - 1);
+          self.package_name_cursor -= 1;
+          self.filter_packages();
+          self.package_autocomplete_selected_index = None;
+          self.package_autocomplete_scroll_offset = 0;
+        }
+      }
+      KeyCode::Delete => {
+        if self.package_name_cursor < self.package_name.len() {
+          self.package_name.remove(self.package_name_cursor);
+          self.filter_packages();
+          self.package_autocomplete_selected_index = None;
+          self.package_autocomplete_scroll_offset = 0;
+        }
+      }
+      KeyCode::Left => {
+        if self.package_name_cursor > 0 {
+          self.package_name_cursor -= 1;
+        }
+      }
+      KeyCode::Right => {
+        if self.package_name_cursor < self.package_name.len() {
+          self.package_name_cursor += 1;
+        }
+      }
+      KeyCode::Home => {
+        self.package_name_cursor = 0;
+      }
+      KeyCode::End => {
+        self.package_name_cursor = self.package_name.len();
+      }
+      KeyCode::Down => {
+        if self.show_package_autocomplete && !self.filtered_packages.is_empty() {
+          let new_idx = match self.package_autocomplete_selected_index {
+            None => 0,
+            Some(idx) => {
+              if idx + 1 < self.filtered_packages.len() {
+                idx + 1
+              } else {
+                0
+              }
+            }
+          };
+
+          self.package_autocomplete_selected_index = Some(new_idx);
+
+          const MAX_VISIBLE: usize = 3;
+          if new_idx >= self.package_autocomplete_scroll_offset + MAX_VISIBLE {
+            self.package_autocomplete_scroll_offset = new_idx - MAX_VISIBLE + 1;
+          } else if new_idx < self.package_autocomplete_scroll_offset {
+            self.package_autocomplete_scroll_offset = new_idx;
+          }
+        }
+      }
+      KeyCode::Up => {
+        if self.show_package_autocomplete && !self.filtered_packages.is_empty() {
+          let new_idx = match self.package_autocomplete_selected_index {
+            None => self.filtered_packages.len() - 1,
+            Some(idx) => {
+              if idx > 0 {
+                idx - 1
+              } else {
+                self.filtered_packages.len() - 1
+              }
+            }
+          };
+
+          self.package_autocomplete_selected_index = Some(new_idx);
+
+          const MAX_VISIBLE: usize = 3;
+          if new_idx >= self.package_autocomplete_scroll_offset + MAX_VISIBLE {
+            self.package_autocomplete_scroll_offset = new_idx - MAX_VISIBLE + 1;
+          } else if new_idx < self.package_autocomplete_scroll_offset {
+            self.package_autocomplete_scroll_offset = new_idx;
+          }
+        }
+      }
+      KeyCode::Tab | KeyCode::Enter => {
+        if self.show_package_autocomplete && !self.filtered_packages.is_empty() {
+          if let Some(idx) = self.package_autocomplete_selected_index {
+            if let Some(selected) = self.filtered_packages.get(idx) {
+              self.package_name = selected.clone();
+              self.package_name_cursor = self.package_name.len();
+              self.show_package_autocomplete = false;
+              self.package_autocomplete_selected_index = None;
+              self.package_autocomplete_scroll_offset = 0;
+              self.filtered_packages.clear();
+            }
+          } else if !self.filtered_packages.is_empty() {
+            self.package_name = self.filtered_packages[0].clone();
+            self.package_name_cursor = self.package_name.len();
+            self.show_package_autocomplete = false;
+            self.package_autocomplete_selected_index = None;
+            self.package_autocomplete_scroll_offset = 0;
+            self.filtered_packages.clear();
+          }
+        } else if key == KeyCode::Enter {
+          self.state.input_mode = InputMode::Normal;
+        }
+      }
+      KeyCode::Esc => {
+        self.show_package_autocomplete = false;
+        self.package_autocomplete_selected_index = None;
+        self.package_autocomplete_scroll_offset = 0;
+      }
+      _ => {}
+    }
+  }
+
+  fn execute_create_jpa_repository(&mut self) {
+    // Validate package name
+    if self.package_name.trim().is_empty() {
+      self.state.error_message = Some("Repository package name is required".to_string());
+      return;
+    }
+
+    // Call command layer to create repository with manual ID
+    let response = create_jpa_repository_command::execute_with_manual_id(
+      &self.cwd,
+      &self.entity_file_b64_src,
+      self.entity_file_path.as_path(),
+      &self.id_field_type,
+      &self.id_field_package,
+    );
+
+    // Use helper function to output response and exit
+    helpers::output_response_and_exit(response, &mut self.state);
+  }
+
+  fn render_title_bar(&self, frame: &mut Frame, area: Rect) {
+    let title = format!("Create JPA Repository for {}", self.entity_name);
+    let title_widget = Paragraph::new(title)
+      .alignment(Alignment::Center)
+      .style(Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD))
+      .block(Block::default().borders(Borders::BOTTOM));
+    frame.render_widget(title_widget, area);
+  }
+
+  fn render_id_type_selector(&mut self, frame: &mut Frame, area: Rect) {
+    let is_focused = self.focused_field == FocusedField::IdFieldType;
+
+    let items: Vec<ListItem> = self
+      .available_id_types
+      .iter()
+      .enumerate()
+      .map(|(i, type_info)| {
+        let is_selected = self.id_type_state.selected() == Some(i);
+        let prefix = if is_selected { "●" } else { "○" };
+        let label = format!(" {} {} ({})", prefix, type_info.name, type_info.package_path);
+        ListItem::new(label)
+      })
+      .collect();
+
+    let border_style =
+      if is_focused { Style::default().fg(Color::Yellow) } else { Style::default() };
+
+    let title_text = if self.auto_detected_id {
+      format!(
+        "ID Field Type (auto-detected: {} from {})",
+        self.id_field_type, self.id_field_package
+      )
+    } else {
+      "ID Field Type (not detected - please select)".to_string()
+    };
+
+    let title = self.generate_title(&title_text, is_focused);
+    let list = List::new(items)
+      .block(Block::default().title(title).borders(Borders::ALL).border_style(border_style))
+      .highlight_style(Style::default().bg(Color::DarkGray).add_modifier(Modifier::BOLD))
+      .highlight_symbol(">> ");
+
+    frame.render_stateful_widget(list, area, &mut self.id_type_state);
+  }
+
+  fn render_package_name_input(&mut self, frame: &mut Frame, area: Rect) {
+    let is_focused = self.focused_field == FocusedField::PackageName;
+    let border_style =
+      if is_focused { Style::default().fg(Color::Yellow) } else { Style::default() };
+
+    let title =
+      if is_focused && self.show_package_autocomplete && !self.filtered_packages.is_empty() {
+        format!(
+          "Repository Package [↑↓ navigate, Tab/Enter select, Esc cancel] ({} matches)",
+          self.filtered_packages.len()
+        )
+      } else {
+        self.generate_title("Repository Package", is_focused)
+      };
+
+    let input = Paragraph::new(self.package_name.as_str())
+      .block(Block::default().title(title).borders(Borders::ALL).border_style(border_style));
+    frame.render_widget(input, area);
+
+    if is_focused && self.state.input_mode == InputMode::Insert {
+      frame.set_cursor_position((area.x + self.package_name_cursor as u16 + 1, area.y + 1));
+    }
+  }
+
+  fn render_autocomplete_dropdown(&self, frame: &mut Frame, area: Rect) {
+    if !self.show_package_autocomplete || self.filtered_packages.is_empty() {
+      return;
+    }
+
+    const MAX_VISIBLE: usize = 3;
+    let total_items = self.filtered_packages.len();
+
+    let visible_start = self.package_autocomplete_scroll_offset;
+    let visible_end = (visible_start + MAX_VISIBLE).min(total_items);
+
+    let list_items: Vec<ListItem> = self
+      .filtered_packages
+      .iter()
+      .enumerate()
+      .skip(visible_start)
+      .take(visible_end - visible_start)
+      .map(|(i, item)| {
+        let is_selected = self.package_autocomplete_selected_index == Some(i);
+        let prefix = if is_selected { "▶" } else { " " };
+        ListItem::new(format!("{} {}", prefix, item)).style(if is_selected {
+          Style::default().bg(Color::DarkGray).fg(Color::White).add_modifier(Modifier::BOLD)
+        } else {
+          Style::default()
+        })
+      })
+      .collect();
+
+    let title = if total_items > MAX_VISIBLE {
+      format!("Suggestions ({}-{} of {})", visible_start + 1, visible_end, total_items)
+    } else {
+      format!("Suggestions ({})", total_items)
+    };
+
+    let list = List::new(list_items).block(
+      Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Cyan))
+        .title(title),
+    );
+
+    frame.render_widget(list, area);
+  }
+
+  fn render_info_panel(&self, frame: &mut Frame, area: Rect) {
+    let info_text = format!(
+      "Repository: {}Repository\nEntity: {} ({})\nID Type: {} ({})",
+      self.entity_name,
+      self.entity_name,
+      Self::extract_entity_package(&self.entity_file_path),
+      self.id_field_type,
+      self.id_field_package
+    );
+
+    let info = Paragraph::new(info_text)
+      .block(
+        Block::default()
+          .title("Repository Details")
+          .borders(Borders::ALL)
+          .border_style(Style::default().fg(Color::Blue)),
+      )
+      .wrap(Wrap { trim: true });
+    frame.render_widget(info, area);
+  }
+
+  fn render_confirm_button(&self, frame: &mut Frame, area: Rect) {
+    let is_focused = self.focused_field == FocusedField::ConfirmButton;
+    let color = match self.state.escape_handler.pressed_once {
+      true => Color::Red,
+      false => Color::Green,
+    };
+    let text = match self.state.escape_handler.pressed_once {
+      true => "Press esc again to close or any key to return",
+      false => "Create Repository",
+    };
+    let style = if is_focused {
+      Style::default().bg(color).fg(Color::Black).add_modifier(Modifier::BOLD)
+    } else {
+      Style::default().fg(color)
+    };
+    let button = Paragraph::new(format!("[ {} ]", text))
+      .alignment(Alignment::Center)
+      .style(style)
+      .block(Block::default().borders(Borders::empty()));
+    frame.render_widget(button, area);
+  }
+
+  pub fn render(&mut self, frame: &mut Frame) {
+    let area = frame.area();
+
+    // Calculate ID type list height dynamically (max 6 lines)
+    let id_type_height = (self.available_id_types.len() as u16 + 2).min(6);
+
+    let chunks = Layout::default()
+      .direction(Direction::Vertical)
+      .constraints([
+        Constraint::Length(2),              // Title bar
+        Constraint::Length(5),              // Info panel
+        Constraint::Length(id_type_height), // ID type selector (dynamic, max 6)
+        Constraint::Length(3),              // Package name input
+        Constraint::Min(3),                 // Flexible space for autocomplete + errors
+        Constraint::Length(1),              // Confirm button
+      ])
+      .split(area);
+
+    self.render_title_bar(frame, chunks[0]);
+    self.render_info_panel(frame, chunks[1]);
+    self.render_id_type_selector(frame, chunks[2]);
+    self.render_package_name_input(frame, chunks[3]);
+
+    // Render autocomplete dropdown and error message in flexible space
+    let flexible_area = chunks[4];
+
+    // Only show autocomplete for package name
+    let show_autocomplete = self.focused_field == FocusedField::PackageName
+      && self.show_package_autocomplete
+      && !self.filtered_packages.is_empty();
+
+    let autocomplete_height = if show_autocomplete { 5 } else { 0 };
+
+    if autocomplete_height > 0 {
+      let autocomplete_chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Length(autocomplete_height), Constraint::Min(0)])
+        .split(flexible_area);
+
+      self.render_autocomplete_dropdown(frame, autocomplete_chunks[0]);
+
+      if let Some(ref error_msg) = self.state.error_message {
+        let error_paragraph =
+          Paragraph::new(error_msg.as_str()).style(Style::default().fg(Color::Red)).block(
+            Block::default()
+              .title("Error")
+              .borders(Borders::ALL)
+              .border_style(Style::default().fg(Color::Red)),
+          );
+        frame.render_widget(error_paragraph, autocomplete_chunks[1]);
+      }
+    } else if let Some(ref error_msg) = self.state.error_message {
+      let error_paragraph =
+        Paragraph::new(error_msg.as_str()).style(Style::default().fg(Color::Red)).block(
+          Block::default()
+            .title("Error")
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(Color::Red)),
+        );
+      frame.render_widget(error_paragraph, flexible_area);
+    }
+
+    self.render_confirm_button(frame, chunks[5]);
+  }
+}
+
+// Implement the FormBehavior trait to get inherited methods
+impl FormBehavior for CreateJpaRepositoryForm {
+  fn form_state(&self) -> &FormState {
+    &self.state
+  }
+
+  fn form_state_mut(&mut self) -> &mut FormState {
+    &mut self.state
+  }
+
+  fn focus_next(&mut self) {
+    CreateJpaRepositoryForm::focus_next(self)
+  }
+
+  fn focus_prev(&mut self) {
+    CreateJpaRepositoryForm::focus_prev(self)
+  }
+
+  fn on_enter_insert_mode(&mut self, key: KeyCode) {
+    CreateJpaRepositoryForm::on_enter_insert_mode(self, key)
+  }
+
+  fn on_enter_pressed(&mut self) {
+    CreateJpaRepositoryForm::on_enter_pressed(self)
+  }
+
+  fn handle_field_insert(&mut self, key: KeyCode) {
+    CreateJpaRepositoryForm::handle_field_insert(self, key)
+  }
+
+  fn render(&mut self, frame: &mut Frame) {
+    CreateJpaRepositoryForm::render(self, frame)
+  }
+}

--- a/src/ui/forms/create_many_to_one_relationship.rs
+++ b/src/ui/forms/create_many_to_one_relationship.rs
@@ -1,0 +1,1327 @@
+#![allow(dead_code)]
+
+use crossterm::event::KeyCode;
+use ratatui::{
+  Frame,
+  layout::{Alignment, Constraint, Direction, Layout, Rect},
+  style::{Color, Modifier, Style},
+  widgets::{Block, Borders, List, ListItem, ListState, Paragraph},
+};
+use std::path::{Path, PathBuf};
+
+use crate::commands::services::{
+  create_jpa_many_to_one_relationship_service, get_all_jpa_entities_service,
+  get_jpa_entity_info_service,
+};
+use crate::common::types::cascade_type::CascadeType;
+use crate::common::types::collection_type::CollectionType;
+use crate::common::types::fetch_type::FetchType;
+use crate::common::types::many_to_one_field_config::ManyToOneFieldConfig;
+use crate::common::types::mapping_type::MappingType;
+use crate::common::types::other_type::OtherType;
+use crate::ui::form_trait::{FormBehavior, FormState, InputMode, helpers};
+
+/// Entity type information
+#[derive(Debug, Clone)]
+struct EntityTypeInfo {
+  name: String,
+  package_name: String,
+}
+
+/// Represents which phase of the form we're in
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum FormPhase {
+  OwningConfiguration,
+  InverseConfiguration,
+}
+
+/// Represents which field is currently focused
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum FocusedField {
+  // Phase 1: Owning Configuration (Many side)
+  MappingType,
+  TargetEntityType,
+  OwningFieldName,
+  InverseFieldName,
+  FetchType,
+  OwningCascades,
+  OwningOther,
+
+  // Phase 2: Inverse Configuration (One side -> becomes OneToMany)
+  CollectionType,
+  InverseCascades,
+  InverseOther,
+
+  // Navigation
+  BackButton,
+  NextButton,
+  ConfirmButton,
+}
+
+/// Parameters for static render functions
+struct RenderContext<'a> {
+  focused_field: FocusedField,
+  form_state: &'a FormState,
+}
+
+/// Parameters for selector rendering
+struct SelectorParams<'a> {
+  field: FocusedField,
+  title: &'a str,
+  selected_indices: &'a [usize],
+}
+
+/// Main form state for creating many-to-one relationships
+pub struct CreateManyToOneRelationshipForm {
+  // Common form state (embedded)
+  state: FormState,
+
+  // Current phase
+  phase: FormPhase,
+
+  // Field values
+  mapping_type_index: usize,
+  target_entity_index: Option<usize>,
+  owning_field_name: String,
+  inverse_field_name: String,
+  fetch_type_index: usize,
+  collection_type_index: usize,
+
+  // Current entity information (owning side - Many side)
+  current_entity_name: String,
+  current_entity_package: String,
+
+  // Entity types available for selection (target entities - excludes current entity)
+  entity_types: Vec<EntityTypeInfo>,
+
+  // Cascade selections (indices of selected items)
+  owning_cascades: Vec<usize>,
+  inverse_cascades: Vec<usize>,
+
+  // Other options (indices of selected items)
+  owning_other: Vec<usize>,
+  inverse_other: Vec<usize>,
+
+  // List states
+  mapping_type_state: ListState,
+  entity_type_state: ListState,
+  fetch_type_state: ListState,
+  collection_type_state: ListState,
+  owning_cascades_state: ListState,
+  inverse_cascades_state: ListState,
+  owning_other_state: ListState,
+  inverse_other_state: ListState,
+
+  // Text input cursors
+  owning_field_name_cursor: usize,
+  inverse_field_name_cursor: usize,
+
+  // Focus management
+  focused_field: FocusedField,
+
+  // Integration with syntaxpresso-core
+  cwd: PathBuf,
+  entity_file_b64_src: String,
+  entity_file_path: PathBuf,
+
+  // Navigation
+  should_go_back: bool,
+  back_pressed_once: bool,
+}
+
+impl CreateManyToOneRelationshipForm {
+  pub fn new(
+    cwd: PathBuf,
+    entity_file_b64_src: String,
+    entity_file_path: PathBuf,
+    _entity_files_json: String, // Not used anymore, we fetch directly
+  ) -> Self {
+    // Fetch current entity info
+    let (current_entity_name, current_entity_package) =
+      Self::fetch_current_entity_info(&entity_file_path, &entity_file_b64_src);
+
+    // Fetch all JPA entities and filter out the current one
+    let entity_types =
+      Self::fetch_target_entities(&cwd, &current_entity_name, &current_entity_package);
+
+    let mut mapping_type_state = ListState::default();
+    mapping_type_state.select(Some(0));
+
+    let mut entity_type_state = ListState::default();
+    entity_type_state.select(Some(0));
+
+    let mut fetch_type_state = ListState::default();
+    fetch_type_state.select(Some(0));
+
+    let mut collection_type_state = ListState::default();
+    collection_type_state.select(Some(0));
+
+    let mut owning_cascades_state = ListState::default();
+    owning_cascades_state.select(Some(0));
+
+    let mut inverse_cascades_state = ListState::default();
+    inverse_cascades_state.select(Some(0));
+
+    let mut owning_other_state = ListState::default();
+    owning_other_state.select(Some(0));
+
+    let mut inverse_other_state = ListState::default();
+    inverse_other_state.select(Some(0));
+
+    Self {
+      state: FormState::new(),
+      phase: FormPhase::OwningConfiguration,
+      mapping_type_index: 0,
+      target_entity_index: None,
+      owning_field_name: String::new(),
+      inverse_field_name: String::new(),
+      fetch_type_index: 0,
+      collection_type_index: 0,
+      current_entity_name,
+      current_entity_package,
+      entity_types,
+      owning_cascades: Vec::new(),
+      inverse_cascades: Vec::new(),
+      owning_other: Vec::new(),
+      inverse_other: Vec::new(),
+      mapping_type_state,
+      entity_type_state,
+      fetch_type_state,
+      collection_type_state,
+      owning_cascades_state,
+      inverse_cascades_state,
+      owning_other_state,
+      inverse_other_state,
+      owning_field_name_cursor: 0,
+      inverse_field_name_cursor: 0,
+      focused_field: FocusedField::MappingType,
+      cwd,
+      entity_file_b64_src,
+      entity_file_path,
+      should_go_back: false,
+      back_pressed_once: false,
+    }
+  }
+
+  /// Fetch current entity information
+  fn fetch_current_entity_info(
+    entity_file_path: &Path,
+    entity_file_b64_src: &str,
+  ) -> (String, String) {
+    match get_jpa_entity_info_service::run(Some(entity_file_path), Some(entity_file_b64_src)) {
+      Ok(entity_info) => (entity_info.entity_type, entity_info.entity_package_name),
+      Err(_) => {
+        // Fallback to unknown if service fails
+        ("Unknown".to_string(), "unknown".to_string())
+      }
+    }
+  }
+
+  /// Fetch all JPA entities and filter out the current entity
+  fn fetch_target_entities(
+    cwd: &Path,
+    current_entity_name: &str,
+    current_entity_package: &str,
+  ) -> Vec<EntityTypeInfo> {
+    match get_all_jpa_entities_service::run(cwd) {
+      Ok(entities) => entities
+        .into_iter()
+        .filter(|entity| {
+          // Exclude the current entity
+          !(entity.file_type == current_entity_name
+            && entity.file_package_name == current_entity_package)
+        })
+        .map(|entity| EntityTypeInfo {
+          name: entity.file_type,
+          package_name: entity.file_package_name,
+        })
+        .collect(),
+      Err(_) => {
+        // Return empty list if service fails
+        Vec::new()
+      }
+    }
+  }
+
+  /// Auto-generate field name from entity type
+  fn auto_field_name(type_name: &str) -> String {
+    if type_name.is_empty() {
+      return String::new();
+    }
+    let mut chars = type_name.chars();
+    if let Some(first) = chars.next() {
+      format!("{}{}", first.to_lowercase(), chars.as_str())
+    } else {
+      String::new()
+    }
+  }
+
+  /// Auto-generate inverse field name from entity type and collection type
+  fn auto_inverse_field_name(entity_name: &str, collection_type_index: usize) -> String {
+    if entity_name.is_empty() {
+      return String::new();
+    }
+    let collection_suffix = match collection_type_index {
+      0 => "List",       // List
+      1 => "Set",        // Set
+      _ => "Collection", // Collection
+    };
+    // Convert to camelCase: entityNameList, entityNameSet, entityNameCollection
+    let base_name = Self::auto_field_name(entity_name);
+    format!("{}{}", base_name, collection_suffix)
+  }
+
+  /// Update target entity and auto-fill owning field name
+  fn update_target_entity(&mut self) {
+    if let Some(idx) = self.entity_type_state.selected() {
+      self.target_entity_index = Some(idx);
+      if let Some(entity) = self.entity_types.get(idx) {
+        // Owning side (Many side): single reference to target entity
+        self.owning_field_name = Self::auto_field_name(&entity.name);
+        self.owning_field_name_cursor = self.owning_field_name.len();
+      }
+    }
+  }
+
+  /// Update inverse field name when collection type or entering inverse phase
+  fn update_inverse_field_name(&mut self) {
+    self.inverse_field_name =
+      Self::auto_inverse_field_name(&self.current_entity_name, self.collection_type_index);
+    self.inverse_field_name_cursor = self.inverse_field_name.len();
+  }
+
+  /// Update mapping type
+  fn update_mapping_type(&mut self) {
+    if let Some(idx) = self.mapping_type_state.selected() {
+      self.mapping_type_index = idx;
+    }
+  }
+
+  /// Update fetch type
+  fn update_fetch_type(&mut self) {
+    if let Some(idx) = self.fetch_type_state.selected() {
+      self.fetch_type_index = idx;
+    }
+  }
+
+  /// Update collection type
+  fn update_collection_type(&mut self) {
+    if let Some(idx) = self.collection_type_state.selected() {
+      self.collection_type_index = idx;
+      // Auto-update inverse field name when collection type changes
+      self.update_inverse_field_name();
+    }
+  }
+
+  /// Check if bidirectional mapping is selected
+  fn is_bidirectional(&self) -> bool {
+    self.mapping_type_index == 0
+  }
+
+  /// Get mapping type from index
+  fn get_mapping_type(&self) -> MappingType {
+    match self.mapping_type_index {
+      0 => MappingType::BidirectionalJoinColumn,
+      _ => MappingType::UnidirectionalJoinColumn,
+    }
+  }
+
+  /// Get fetch type from index
+  fn get_fetch_type(&self) -> FetchType {
+    match self.fetch_type_index {
+      0 => FetchType::Lazy,
+      _ => FetchType::Eager,
+    }
+  }
+
+  /// Get collection type from index
+  fn get_collection_type(&self) -> CollectionType {
+    match self.collection_type_index {
+      0 => CollectionType::List,
+      1 => CollectionType::Set,
+      _ => CollectionType::Collection,
+    }
+  }
+
+  /// Get cascade types from indices
+  fn get_cascade_types(indices: &[usize]) -> Vec<CascadeType> {
+    let all_cascades = Self::get_all_cascades();
+    indices.iter().filter_map(|&i| all_cascades.get(i).cloned()).collect()
+  }
+
+  /// Get other types from indices
+  fn get_other_types(indices: &[usize], is_owning: bool) -> Vec<OtherType> {
+    let all_others =
+      if is_owning { Self::get_owning_other_options() } else { Self::get_inverse_other_options() };
+    indices.iter().filter_map(|&i| all_others.get(i).cloned()).collect()
+  }
+
+  /// Get all cascade types
+  fn get_all_cascades() -> Vec<CascadeType> {
+    vec![
+      CascadeType::Persist,
+      CascadeType::Merge,
+      CascadeType::Remove,
+      CascadeType::Refresh,
+      CascadeType::Detach,
+    ]
+  }
+
+  /// Get owning side other options (Many side)
+  fn get_owning_other_options() -> Vec<OtherType> {
+    vec![OtherType::Mandatory, OtherType::Unique]
+  }
+
+  /// Get inverse side other options (One side)
+  fn get_inverse_other_options() -> Vec<OtherType> {
+    vec![OtherType::OrphanRemoval]
+  }
+
+  /// Toggle item in a list
+  fn toggle_in_list(list: &mut Vec<usize>, index: usize) {
+    if let Some(pos) = list.iter().position(|&i| i == index) {
+      list.remove(pos);
+    } else {
+      list.push(index);
+    }
+  }
+
+  /// Check if user wants to go back
+  pub fn should_go_back(&self) -> bool {
+    self.should_go_back
+  }
+
+  /// Generate title with insert mode indicator
+  fn generate_title(&self, base: &str, is_focused: bool) -> String {
+    if is_focused && self.state.input_mode == InputMode::Insert {
+      format!("{} [INSERT]", base)
+    } else {
+      base.to_string()
+    }
+  }
+
+  /// Move focus to the next visible field
+  fn focus_next(&mut self) {
+    self.back_pressed_once = false;
+
+    self.focused_field = match self.phase {
+      FormPhase::OwningConfiguration => match self.focused_field {
+        FocusedField::MappingType => FocusedField::TargetEntityType,
+        FocusedField::TargetEntityType => FocusedField::OwningFieldName,
+        FocusedField::OwningFieldName => FocusedField::FetchType,
+        FocusedField::FetchType => FocusedField::OwningCascades,
+        FocusedField::OwningCascades => FocusedField::OwningOther,
+        FocusedField::OwningOther => FocusedField::BackButton,
+        FocusedField::BackButton => {
+          if self.is_bidirectional() {
+            FocusedField::NextButton
+          } else {
+            FocusedField::ConfirmButton
+          }
+        }
+        FocusedField::NextButton => FocusedField::MappingType,
+        FocusedField::ConfirmButton => FocusedField::MappingType,
+        _ => FocusedField::MappingType,
+      },
+      FormPhase::InverseConfiguration => match self.focused_field {
+        FocusedField::CollectionType => FocusedField::InverseFieldName,
+        FocusedField::InverseFieldName => FocusedField::InverseCascades,
+        FocusedField::InverseCascades => FocusedField::InverseOther,
+        FocusedField::InverseOther => FocusedField::BackButton,
+        FocusedField::BackButton => FocusedField::ConfirmButton,
+        FocusedField::ConfirmButton => FocusedField::CollectionType,
+        _ => FocusedField::CollectionType,
+      },
+    };
+  }
+
+  /// Move focus to the previous visible field
+  fn focus_prev(&mut self) {
+    self.back_pressed_once = false;
+
+    self.focused_field = match self.phase {
+      FormPhase::OwningConfiguration => match self.focused_field {
+        FocusedField::MappingType => {
+          if self.is_bidirectional() {
+            FocusedField::NextButton
+          } else {
+            FocusedField::ConfirmButton
+          }
+        }
+        FocusedField::TargetEntityType => FocusedField::MappingType,
+        FocusedField::OwningFieldName => FocusedField::TargetEntityType,
+        FocusedField::FetchType => FocusedField::OwningFieldName,
+        FocusedField::OwningCascades => FocusedField::FetchType,
+        FocusedField::OwningOther => FocusedField::OwningCascades,
+        FocusedField::BackButton => FocusedField::OwningOther,
+        FocusedField::NextButton => FocusedField::BackButton,
+        FocusedField::ConfirmButton => FocusedField::BackButton,
+        _ => FocusedField::MappingType,
+      },
+      FormPhase::InverseConfiguration => match self.focused_field {
+        FocusedField::CollectionType => FocusedField::ConfirmButton,
+        FocusedField::InverseFieldName => FocusedField::CollectionType,
+        FocusedField::InverseCascades => FocusedField::InverseFieldName,
+        FocusedField::InverseOther => FocusedField::InverseCascades,
+        FocusedField::BackButton => FocusedField::InverseOther,
+        FocusedField::ConfirmButton => FocusedField::BackButton,
+        _ => FocusedField::CollectionType,
+      },
+    };
+  }
+
+  /// Called when entering insert mode
+  fn on_enter_insert_mode(&mut self, key: KeyCode) {
+    if key == KeyCode::Char('a') {
+      match self.focused_field {
+        FocusedField::OwningFieldName => {
+          self.owning_field_name_cursor = self.owning_field_name.len();
+        }
+        FocusedField::InverseFieldName => {
+          self.inverse_field_name_cursor = self.inverse_field_name.len();
+        }
+        _ => {}
+      }
+    }
+  }
+
+  /// Called when Enter is pressed in Normal mode
+  fn on_enter_pressed(&mut self) {
+    match self.focused_field {
+      FocusedField::NextButton => {
+        // Move to inverse configuration phase
+        self.phase = FormPhase::InverseConfiguration;
+        self.focused_field = FocusedField::CollectionType;
+        self.back_pressed_once = false;
+        // Auto-generate inverse field name based on current collection type
+        self.update_inverse_field_name();
+      }
+      FocusedField::ConfirmButton => {
+        self.execute_create_relationship();
+      }
+      FocusedField::BackButton => {
+        if self.back_pressed_once {
+          // If in inverse phase, go back to owning phase
+          if self.phase == FormPhase::InverseConfiguration {
+            self.phase = FormPhase::OwningConfiguration;
+            self.focused_field = FocusedField::MappingType;
+            self.back_pressed_once = false;
+          } else {
+            // If in owning phase, go back to parent form
+            self.should_go_back = true;
+          }
+        } else {
+          self.back_pressed_once = true;
+        }
+      }
+      _ => {}
+    }
+  }
+
+  fn execute_create_relationship(&mut self) {
+    // Validate
+    let target_entity_name = match self.target_entity_index {
+      Some(idx) => match self.entity_types.get(idx) {
+        Some(entity) => entity.name.clone(),
+        None => {
+          self.state.error_message = Some("No target entity selected".to_string());
+          return;
+        }
+      },
+      None => {
+        self.state.error_message = Some("Target entity type is required".to_string());
+        return;
+      }
+    };
+
+    if self.owning_field_name.is_empty() {
+      self.state.error_message = Some("Owning side field name is required".to_string());
+      return;
+    }
+
+    if self.is_bidirectional() && self.inverse_field_name.is_empty() {
+      self.state.error_message =
+        Some("Inverse side field name is required for bidirectional relationships".to_string());
+      return;
+    }
+
+    // Build field config
+    let field_config = ManyToOneFieldConfig {
+      inverse_field_type: target_entity_name,
+      fetch_type: self.get_fetch_type(),
+      collection_type: self.get_collection_type(),
+      mapping_type: Some(self.get_mapping_type()),
+      owning_side_cascades: Self::get_cascade_types(&self.owning_cascades),
+      inverse_side_cascades: Self::get_cascade_types(&self.inverse_cascades),
+      owning_side_other: Self::get_other_types(&self.owning_other, true),
+      inverse_side_other: Self::get_other_types(&self.inverse_other, false),
+    };
+
+    // Call service
+    match create_jpa_many_to_one_relationship_service::run(
+      &self.cwd,
+      &self.entity_file_b64_src,
+      &self.entity_file_path,
+      &self.owning_field_name,
+      &self.inverse_field_name,
+      &field_config,
+    ) {
+      Ok(responses) => {
+        eprintln!("Successfully created many-to-one relationship in {} file(s)", responses.len());
+        for response in responses {
+          eprintln!(
+            "  - {} in {} at {}",
+            response.file_type, response.file_package_name, response.file_path
+          );
+        }
+        self.state.should_quit = true;
+        std::process::exit(0);
+      }
+      Err(e) => {
+        self.state.error_message = Some(format!("Error: {}", e));
+      }
+    }
+  }
+
+  /// Handle field-specific input in Insert mode
+  fn handle_field_insert_impl(&mut self, key: KeyCode) {
+    match self.focused_field {
+      FocusedField::MappingType => match key {
+        KeyCode::Char('j') | KeyCode::Down => {
+          helpers::navigate_list_static(&KeyCode::Down, &mut self.mapping_type_state, 2);
+          self.update_mapping_type();
+        }
+        KeyCode::Char('k') | KeyCode::Up => {
+          helpers::navigate_list_static(&KeyCode::Up, &mut self.mapping_type_state, 2);
+          self.update_mapping_type();
+        }
+        KeyCode::Enter => {
+          self.state.input_mode = InputMode::Normal;
+        }
+        _ => {}
+      },
+      FocusedField::TargetEntityType => match key {
+        KeyCode::Char('j') | KeyCode::Down => {
+          let len = self.entity_types.len();
+          helpers::navigate_list_static(&KeyCode::Down, &mut self.entity_type_state, len);
+          self.update_target_entity();
+        }
+        KeyCode::Char('k') | KeyCode::Up => {
+          let len = self.entity_types.len();
+          helpers::navigate_list_static(&KeyCode::Up, &mut self.entity_type_state, len);
+          self.update_target_entity();
+        }
+        KeyCode::Enter => {
+          self.state.input_mode = InputMode::Normal;
+        }
+        _ => {}
+      },
+      FocusedField::OwningFieldName => {
+        helpers::handle_text_input(
+          key,
+          &mut self.owning_field_name,
+          &mut self.owning_field_name_cursor,
+          &mut self.state.input_mode,
+        );
+      }
+      FocusedField::InverseFieldName => {
+        helpers::handle_text_input(
+          key,
+          &mut self.inverse_field_name,
+          &mut self.inverse_field_name_cursor,
+          &mut self.state.input_mode,
+        );
+      }
+      FocusedField::FetchType => match key {
+        KeyCode::Char('j') | KeyCode::Down => {
+          helpers::navigate_list_static(&KeyCode::Down, &mut self.fetch_type_state, 2);
+          self.update_fetch_type();
+        }
+        KeyCode::Char('k') | KeyCode::Up => {
+          helpers::navigate_list_static(&KeyCode::Up, &mut self.fetch_type_state, 2);
+          self.update_fetch_type();
+        }
+        KeyCode::Enter => {
+          self.state.input_mode = InputMode::Normal;
+        }
+        _ => {}
+      },
+      FocusedField::CollectionType => match key {
+        KeyCode::Char('j') | KeyCode::Down => {
+          helpers::navigate_list_static(&KeyCode::Down, &mut self.collection_type_state, 3);
+          self.update_collection_type();
+        }
+        KeyCode::Char('k') | KeyCode::Up => {
+          helpers::navigate_list_static(&KeyCode::Up, &mut self.collection_type_state, 3);
+          self.update_collection_type();
+        }
+        KeyCode::Enter => {
+          self.state.input_mode = InputMode::Normal;
+        }
+        _ => {}
+      },
+      FocusedField::OwningCascades | FocusedField::InverseCascades => {
+        let state = if matches!(self.focused_field, FocusedField::OwningCascades) {
+          &mut self.owning_cascades_state
+        } else {
+          &mut self.inverse_cascades_state
+        };
+        let list = if matches!(self.focused_field, FocusedField::OwningCascades) {
+          &mut self.owning_cascades
+        } else {
+          &mut self.inverse_cascades
+        };
+
+        match key {
+          KeyCode::Char('j') | KeyCode::Down => {
+            let len = Self::get_all_cascades().len();
+            helpers::navigate_list_static(&KeyCode::Down, state, len);
+          }
+          KeyCode::Char('k') | KeyCode::Up => {
+            let len = Self::get_all_cascades().len();
+            helpers::navigate_list_static(&KeyCode::Up, state, len);
+          }
+          KeyCode::Char(' ') | KeyCode::Enter => {
+            if let Some(idx) = state.selected() {
+              Self::toggle_in_list(list, idx);
+            }
+            if key == KeyCode::Enter {
+              self.state.input_mode = InputMode::Normal;
+            }
+          }
+          _ => {}
+        }
+      }
+      FocusedField::OwningOther | FocusedField::InverseOther => {
+        let state = if matches!(self.focused_field, FocusedField::OwningOther) {
+          &mut self.owning_other_state
+        } else {
+          &mut self.inverse_other_state
+        };
+        let list = if matches!(self.focused_field, FocusedField::OwningOther) {
+          &mut self.owning_other
+        } else {
+          &mut self.inverse_other
+        };
+        let len = if matches!(self.focused_field, FocusedField::OwningOther) {
+          Self::get_owning_other_options().len()
+        } else {
+          Self::get_inverse_other_options().len()
+        };
+
+        match key {
+          KeyCode::Char('j') | KeyCode::Down => {
+            helpers::navigate_list_static(&KeyCode::Down, state, len);
+          }
+          KeyCode::Char('k') | KeyCode::Up => {
+            helpers::navigate_list_static(&KeyCode::Up, state, len);
+          }
+          KeyCode::Char(' ') | KeyCode::Enter => {
+            if let Some(idx) = state.selected() {
+              Self::toggle_in_list(list, idx);
+            }
+            if key == KeyCode::Enter {
+              self.state.input_mode = InputMode::Normal;
+            }
+          }
+          _ => {}
+        }
+      }
+      FocusedField::NextButton => {
+        if key == KeyCode::Enter {
+          self.phase = FormPhase::InverseConfiguration;
+          self.focused_field = FocusedField::CollectionType;
+          self.back_pressed_once = false;
+          self.state.input_mode = InputMode::Normal;
+          // Auto-generate inverse field name based on current collection type
+          self.update_inverse_field_name();
+        }
+      }
+      FocusedField::BackButton => {
+        if key == KeyCode::Enter {
+          if self.back_pressed_once {
+            if self.phase == FormPhase::InverseConfiguration {
+              self.phase = FormPhase::OwningConfiguration;
+              self.focused_field = FocusedField::MappingType;
+              self.back_pressed_once = false;
+              self.state.input_mode = InputMode::Normal;
+            } else {
+              self.should_go_back = true;
+            }
+          } else {
+            self.back_pressed_once = true;
+          }
+        }
+      }
+      FocusedField::ConfirmButton => {
+        if key == KeyCode::Enter {
+          self.execute_create_relationship();
+        }
+      }
+    }
+  }
+
+  pub fn render_impl(&mut self, frame: &mut Frame) {
+    match self.phase {
+      FormPhase::OwningConfiguration => self.render_owning_phase(frame),
+      FormPhase::InverseConfiguration => self.render_inverse_phase(frame),
+    }
+  }
+
+  fn render_owning_phase(&mut self, frame: &mut Frame) {
+    let area = frame.area();
+
+    let chunks = Layout::default()
+      .direction(Direction::Vertical)
+      .constraints([
+        Constraint::Length(2), // Title
+        Constraint::Length(4), // Mapping type
+        Constraint::Length(9), // Entity type
+        Constraint::Length(3), // Owning field name
+        Constraint::Length(4), // Fetch type
+        Constraint::Length(7), // Owning cascades
+        Constraint::Length(4), // Owning other
+        Constraint::Min(0),    // Errors
+        Constraint::Length(1), // Buttons
+      ])
+      .split(area);
+
+    let mut idx = 0;
+
+    // Title
+    let title = Paragraph::new("Many-to-One: Owning Side Configuration")
+      .alignment(Alignment::Center)
+      .style(Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD))
+      .block(Block::default().borders(Borders::BOTTOM));
+    frame.render_widget(title, chunks[idx]);
+    idx += 1;
+
+    // Mapping type
+    self.render_mapping_type_selector(frame, chunks[idx]);
+    idx += 1;
+
+    // Entity type
+    self.render_entity_type_selector(frame, chunks[idx]);
+    idx += 1;
+
+    // Owning field name
+    self.render_text_input(
+      frame,
+      chunks[idx],
+      FocusedField::OwningFieldName,
+      "Owning Side Field Name (Many side)",
+      &self.owning_field_name.clone(),
+      self.owning_field_name_cursor,
+    );
+    idx += 1;
+
+    // Fetch type
+    self.render_fetch_type_selector(frame, chunks[idx]);
+    idx += 1;
+
+    // Cascades
+    let ctx = RenderContext { focused_field: self.focused_field, form_state: &self.state };
+    let params = SelectorParams {
+      field: FocusedField::OwningCascades,
+      title: "Owning Side Cascade Types (Space to toggle)",
+      selected_indices: &self.owning_cascades,
+    };
+    Self::render_cascade_selector_static(
+      frame,
+      chunks[idx],
+      &mut self.owning_cascades_state,
+      &params,
+      &ctx,
+    );
+    idx += 1;
+
+    // Other options
+    let params = SelectorParams {
+      field: FocusedField::OwningOther,
+      title: "Owning Side Options (Space to toggle)",
+      selected_indices: &self.owning_other,
+    };
+    Self::render_other_selector_static(
+      frame,
+      chunks[idx],
+      &mut self.owning_other_state,
+      &params,
+      true,
+      &ctx,
+    );
+    idx += 1;
+
+    // Error
+    if let Some(ref error_msg) = self.state.error_message {
+      let error_paragraph =
+        Paragraph::new(error_msg.as_str()).style(Style::default().fg(Color::Red)).block(
+          Block::default()
+            .title("Error")
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(Color::Red)),
+        );
+      frame.render_widget(error_paragraph, chunks[idx]);
+    }
+    idx += 1;
+
+    // Buttons
+    self.render_owning_phase_buttons(frame, chunks[idx]);
+  }
+
+  fn render_inverse_phase(&mut self, frame: &mut Frame) {
+    let area = frame.area();
+
+    let chunks = Layout::default()
+      .direction(Direction::Vertical)
+      .constraints([
+        Constraint::Length(2), // Title
+        Constraint::Length(5), // Collection type
+        Constraint::Length(3), // Inverse field name
+        Constraint::Length(7), // Inverse cascades
+        Constraint::Length(3), // Inverse other
+        Constraint::Min(0),    // Errors
+        Constraint::Length(1), // Buttons
+      ])
+      .split(area);
+
+    let mut idx = 0;
+
+    // Title
+    let title = Paragraph::new("Many-to-One: Inverse Side (One-to-Many) Configuration")
+      .alignment(Alignment::Center)
+      .style(Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD))
+      .block(Block::default().borders(Borders::BOTTOM));
+    frame.render_widget(title, chunks[idx]);
+    idx += 1;
+
+    // Collection type
+    self.render_collection_type_selector(frame, chunks[idx]);
+    idx += 1;
+
+    // Inverse field name
+    self.render_text_input(
+      frame,
+      chunks[idx],
+      FocusedField::InverseFieldName,
+      "Inverse Side Field Name (One side)",
+      &self.inverse_field_name.clone(),
+      self.inverse_field_name_cursor,
+    );
+    idx += 1;
+
+    // Cascades
+    let ctx = RenderContext { focused_field: self.focused_field, form_state: &self.state };
+    let params = SelectorParams {
+      field: FocusedField::InverseCascades,
+      title: "Inverse Side Cascade Types (Space to toggle)",
+      selected_indices: &self.inverse_cascades,
+    };
+    Self::render_cascade_selector_static(
+      frame,
+      chunks[idx],
+      &mut self.inverse_cascades_state,
+      &params,
+      &ctx,
+    );
+    idx += 1;
+
+    // Other options
+    let params = SelectorParams {
+      field: FocusedField::InverseOther,
+      title: "Inverse Side Options (Space to toggle)",
+      selected_indices: &self.inverse_other,
+    };
+    Self::render_other_selector_static(
+      frame,
+      chunks[idx],
+      &mut self.inverse_other_state,
+      &params,
+      false,
+      &ctx,
+    );
+    idx += 1;
+
+    // Error
+    if let Some(ref error_msg) = self.state.error_message {
+      let error_paragraph =
+        Paragraph::new(error_msg.as_str()).style(Style::default().fg(Color::Red)).block(
+          Block::default()
+            .title("Error")
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(Color::Red)),
+        );
+      frame.render_widget(error_paragraph, chunks[idx]);
+    }
+    idx += 1;
+
+    // Buttons
+    self.render_buttons(frame, chunks[idx]);
+  }
+
+  fn render_mapping_type_selector(&mut self, frame: &mut Frame, area: Rect) {
+    let is_focused = self.focused_field == FocusedField::MappingType;
+
+    let mapping_types = ["Bidirectional (Recommended)", "Unidirectional with Join Column"];
+    let items: Vec<ListItem> = mapping_types
+      .iter()
+      .enumerate()
+      .map(|(i, name)| {
+        let is_selected = self.mapping_type_state.selected() == Some(i);
+        let prefix = if is_selected { "●" } else { "○" };
+        ListItem::new(format!(" {} {}", prefix, name))
+      })
+      .collect();
+
+    let border_style =
+      if is_focused { Style::default().fg(Color::Yellow) } else { Style::default() };
+
+    let title = self.generate_title("Mapping Type", is_focused);
+    let list = List::new(items)
+      .block(Block::default().title(title).borders(Borders::ALL).border_style(border_style))
+      .highlight_style(Style::default().bg(Color::DarkGray).add_modifier(Modifier::BOLD))
+      .highlight_symbol(">> ");
+
+    frame.render_stateful_widget(list, area, &mut self.mapping_type_state);
+  }
+
+  fn render_entity_type_selector(&mut self, frame: &mut Frame, area: Rect) {
+    let is_focused = self.focused_field == FocusedField::TargetEntityType;
+
+    let items: Vec<ListItem> = self
+      .entity_types
+      .iter()
+      .enumerate()
+      .map(|(i, entity)| {
+        let is_selected = self.entity_type_state.selected() == Some(i);
+        let prefix = if is_selected { "●" } else { "○" };
+        ListItem::new(format!(" {} {} ({})", prefix, entity.name, entity.package_name))
+      })
+      .collect();
+
+    let border_style =
+      if is_focused { Style::default().fg(Color::Yellow) } else { Style::default() };
+
+    let title = self.generate_title("Target Entity Type (the 'One' side)", is_focused);
+    let list = List::new(items)
+      .block(Block::default().title(title).borders(Borders::ALL).border_style(border_style))
+      .highlight_style(Style::default().bg(Color::DarkGray).add_modifier(Modifier::BOLD))
+      .highlight_symbol(">> ");
+
+    frame.render_stateful_widget(list, area, &mut self.entity_type_state);
+  }
+
+  fn render_fetch_type_selector(&mut self, frame: &mut Frame, area: Rect) {
+    let is_focused = self.focused_field == FocusedField::FetchType;
+
+    let fetch_types = ["Lazy (Default)", "Eager"];
+    let items: Vec<ListItem> = fetch_types
+      .iter()
+      .enumerate()
+      .map(|(i, name)| {
+        let is_selected = self.fetch_type_state.selected() == Some(i);
+        let prefix = if is_selected { "●" } else { "○" };
+        ListItem::new(format!(" {} {}", prefix, name))
+      })
+      .collect();
+
+    let border_style =
+      if is_focused { Style::default().fg(Color::Yellow) } else { Style::default() };
+
+    let title = self.generate_title("Fetch Type", is_focused);
+    let list = List::new(items)
+      .block(Block::default().title(title).borders(Borders::ALL).border_style(border_style))
+      .highlight_style(Style::default().bg(Color::DarkGray).add_modifier(Modifier::BOLD))
+      .highlight_symbol(">> ");
+
+    frame.render_stateful_widget(list, area, &mut self.fetch_type_state);
+  }
+
+  fn render_collection_type_selector(&mut self, frame: &mut Frame, area: Rect) {
+    let is_focused = self.focused_field == FocusedField::CollectionType;
+
+    let collection_types = ["List", "Set", "Collection"];
+    let items: Vec<ListItem> = collection_types
+      .iter()
+      .enumerate()
+      .map(|(i, name)| {
+        let is_selected = self.collection_type_state.selected() == Some(i);
+        let prefix = if is_selected { "●" } else { "○" };
+        ListItem::new(format!(" {} {}", prefix, name))
+      })
+      .collect();
+
+    let border_style =
+      if is_focused { Style::default().fg(Color::Yellow) } else { Style::default() };
+
+    let title = self.generate_title("Collection Type", is_focused);
+    let list = List::new(items)
+      .block(Block::default().title(title).borders(Borders::ALL).border_style(border_style))
+      .highlight_style(Style::default().bg(Color::DarkGray).add_modifier(Modifier::BOLD))
+      .highlight_symbol(">> ");
+
+    frame.render_stateful_widget(list, area, &mut self.collection_type_state);
+  }
+
+  fn render_text_input(
+    &self,
+    frame: &mut Frame,
+    area: Rect,
+    field: FocusedField,
+    title: &str,
+    text: &str,
+    cursor: usize,
+  ) {
+    let is_focused = self.focused_field == field;
+    let border_style =
+      if is_focused { Style::default().fg(Color::Yellow) } else { Style::default() };
+
+    let title = self.generate_title(title, is_focused);
+    let input = Paragraph::new(text)
+      .block(Block::default().title(title).borders(Borders::ALL).border_style(border_style));
+    frame.render_widget(input, area);
+
+    if is_focused && self.state.input_mode == InputMode::Insert {
+      frame.set_cursor_position((area.x + cursor as u16 + 1, area.y + 1));
+    }
+  }
+
+  #[allow(clippy::too_many_arguments)]
+  fn render_cascade_selector(
+    &self,
+    frame: &mut Frame,
+    area: Rect,
+    field: FocusedField,
+    title: &str,
+    selected_indices: &[usize],
+    state: &mut ListState,
+  ) {
+    let ctx = RenderContext { focused_field: self.focused_field, form_state: &self.state };
+    let params = SelectorParams { field, title, selected_indices };
+    Self::render_cascade_selector_static(frame, area, state, &params, &ctx)
+  }
+
+  fn render_cascade_selector_static(
+    frame: &mut Frame,
+    area: Rect,
+    state: &mut ListState,
+    params: &SelectorParams,
+    ctx: &RenderContext,
+  ) {
+    let is_focused = ctx.focused_field == params.field;
+    let cascades = Self::get_all_cascades();
+
+    let items: Vec<ListItem> = cascades
+      .iter()
+      .enumerate()
+      .map(|(i, cascade)| {
+        let is_selected = params.selected_indices.contains(&i);
+        let checkbox = if is_selected { "[x]" } else { "[ ]" };
+        ListItem::new(format!(" {} {}", checkbox, cascade.as_str()))
+      })
+      .collect();
+
+    let border_style =
+      if is_focused { Style::default().fg(Color::Yellow) } else { Style::default() };
+
+    let title_text = if is_focused && ctx.form_state.input_mode == InputMode::Insert {
+      format!("{} [INSERT]", params.title)
+    } else {
+      params.title.to_string()
+    };
+
+    let list = List::new(items)
+      .block(Block::default().title(title_text).borders(Borders::ALL).border_style(border_style))
+      .highlight_style(Style::default().bg(Color::DarkGray).add_modifier(Modifier::BOLD))
+      .highlight_symbol(">> ");
+
+    frame.render_stateful_widget(list, area, state);
+  }
+
+  #[allow(clippy::too_many_arguments)]
+  fn render_other_selector(
+    &self,
+    frame: &mut Frame,
+    area: Rect,
+    field: FocusedField,
+    title: &str,
+    selected_indices: &[usize],
+    state: &mut ListState,
+    is_owning: bool,
+  ) {
+    let ctx = RenderContext { focused_field: self.focused_field, form_state: &self.state };
+    let params = SelectorParams { field, title, selected_indices };
+    Self::render_other_selector_static(frame, area, state, &params, is_owning, &ctx)
+  }
+
+  fn render_other_selector_static(
+    frame: &mut Frame,
+    area: Rect,
+    state: &mut ListState,
+    params: &SelectorParams,
+    is_owning: bool,
+    ctx: &RenderContext,
+  ) {
+    let is_focused = ctx.focused_field == params.field;
+    let options =
+      if is_owning { Self::get_owning_other_options() } else { Self::get_inverse_other_options() };
+
+    let items: Vec<ListItem> = options
+      .iter()
+      .enumerate()
+      .map(|(i, other)| {
+        let is_selected = params.selected_indices.contains(&i);
+        let checkbox = if is_selected { "[x]" } else { "[ ]" };
+        let display = match other {
+          OtherType::Mandatory => "Mandatory",
+          OtherType::Unique => "Unique",
+          OtherType::OrphanRemoval => "Orphan Removal",
+          OtherType::LargeObject => "Large Object",
+          OtherType::EqualsHashcode => "Equals/Hashcode",
+          OtherType::Mutable => "Mutable",
+        };
+        ListItem::new(format!(" {} {}", checkbox, display))
+      })
+      .collect();
+
+    let border_style =
+      if is_focused { Style::default().fg(Color::Yellow) } else { Style::default() };
+
+    let title_text = if is_focused && ctx.form_state.input_mode == InputMode::Insert {
+      format!("{} [INSERT]", params.title)
+    } else {
+      params.title.to_string()
+    };
+
+    let list = List::new(items)
+      .block(Block::default().title(title_text).borders(Borders::ALL).border_style(border_style))
+      .highlight_style(Style::default().bg(Color::DarkGray).add_modifier(Modifier::BOLD))
+      .highlight_symbol(">> ");
+
+    frame.render_stateful_widget(list, area, state);
+  }
+
+  fn render_owning_phase_buttons(&self, frame: &mut Frame, area: Rect) {
+    let chunks = Layout::default()
+      .direction(Direction::Horizontal)
+      .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+      .split(area);
+
+    // Back button
+    let is_back_focused = self.focused_field == FocusedField::BackButton;
+    let back_color = if self.back_pressed_once { Color::Red } else { Color::Yellow };
+    let back_text = if self.back_pressed_once { "Press again to go back" } else { "Back" };
+    let back_style = if is_back_focused {
+      Style::default().bg(back_color).fg(Color::Black).add_modifier(Modifier::BOLD)
+    } else {
+      Style::default().fg(back_color)
+    };
+    let back_button = Paragraph::new(format!("[ {} ]", back_text))
+      .alignment(Alignment::Center)
+      .style(back_style)
+      .block(Block::default().borders(Borders::empty()));
+    frame.render_widget(back_button, chunks[0]);
+
+    // Next/Confirm button
+    if self.is_bidirectional() {
+      let is_next_focused = self.focused_field == FocusedField::NextButton;
+      let next_style = if is_next_focused {
+        Style::default().bg(Color::Green).fg(Color::Black).add_modifier(Modifier::BOLD)
+      } else {
+        Style::default().fg(Color::Green)
+      };
+      let next_button = Paragraph::new("[ Next -> ]")
+        .alignment(Alignment::Center)
+        .style(next_style)
+        .block(Block::default().borders(Borders::empty()));
+      frame.render_widget(next_button, chunks[1]);
+    } else {
+      let is_confirm_focused = self.focused_field == FocusedField::ConfirmButton;
+      let color = if self.state.escape_handler.pressed_once { Color::Red } else { Color::Green };
+      let text =
+        if self.state.escape_handler.pressed_once { "Press esc again to close" } else { "Confirm" };
+      let confirm_style = if is_confirm_focused {
+        Style::default().bg(color).fg(Color::Black).add_modifier(Modifier::BOLD)
+      } else {
+        Style::default().fg(color)
+      };
+      let confirm_button = Paragraph::new(format!("[ {} ]", text))
+        .alignment(Alignment::Center)
+        .style(confirm_style)
+        .block(Block::default().borders(Borders::empty()));
+      frame.render_widget(confirm_button, chunks[1]);
+    }
+  }
+
+  fn render_buttons(&self, frame: &mut Frame, area: Rect) {
+    let chunks = Layout::default()
+      .direction(Direction::Horizontal)
+      .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+      .split(area);
+
+    // Back button
+    let is_back_focused = self.focused_field == FocusedField::BackButton;
+    let back_color = if self.back_pressed_once { Color::Red } else { Color::Yellow };
+    let back_text = if self.back_pressed_once { "Press again to go back" } else { "Back" };
+    let back_style = if is_back_focused {
+      Style::default().bg(back_color).fg(Color::Black).add_modifier(Modifier::BOLD)
+    } else {
+      Style::default().fg(back_color)
+    };
+    let back_button = Paragraph::new(format!("[ {} ]", back_text))
+      .alignment(Alignment::Center)
+      .style(back_style)
+      .block(Block::default().borders(Borders::empty()));
+    frame.render_widget(back_button, chunks[0]);
+
+    // Confirm button
+    let is_confirm_focused = self.focused_field == FocusedField::ConfirmButton;
+    let color = if self.state.escape_handler.pressed_once { Color::Red } else { Color::Green };
+    let text =
+      if self.state.escape_handler.pressed_once { "Press esc again to close" } else { "Confirm" };
+    let confirm_style = if is_confirm_focused {
+      Style::default().bg(color).fg(Color::Black).add_modifier(Modifier::BOLD)
+    } else {
+      Style::default().fg(color)
+    };
+    let confirm_button = Paragraph::new(format!("[ {} ]", text))
+      .alignment(Alignment::Center)
+      .style(confirm_style)
+      .block(Block::default().borders(Borders::empty()));
+    frame.render_widget(confirm_button, chunks[1]);
+  }
+}
+
+// Implement the FormBehavior trait
+impl FormBehavior for CreateManyToOneRelationshipForm {
+  fn form_state(&self) -> &FormState {
+    &self.state
+  }
+
+  fn form_state_mut(&mut self) -> &mut FormState {
+    &mut self.state
+  }
+
+  fn focus_next(&mut self) {
+    CreateManyToOneRelationshipForm::focus_next(self)
+  }
+
+  fn focus_prev(&mut self) {
+    CreateManyToOneRelationshipForm::focus_prev(self)
+  }
+
+  fn on_enter_insert_mode(&mut self, key: KeyCode) {
+    CreateManyToOneRelationshipForm::on_enter_insert_mode(self, key)
+  }
+
+  fn on_enter_pressed(&mut self) {
+    CreateManyToOneRelationshipForm::on_enter_pressed(self)
+  }
+
+  fn handle_field_insert(&mut self, key: KeyCode) {
+    CreateManyToOneRelationshipForm::handle_field_insert_impl(self, key)
+  }
+
+  fn render(&mut self, frame: &mut Frame) {
+    CreateManyToOneRelationshipForm::render_impl(self, frame)
+  }
+}

--- a/src/ui/forms/create_one_to_one_relationship.rs
+++ b/src/ui/forms/create_one_to_one_relationship.rs
@@ -1,0 +1,1229 @@
+#![allow(dead_code)]
+
+use crossterm::event::KeyCode;
+use ratatui::{
+  Frame,
+  layout::{Alignment, Constraint, Direction, Layout, Rect},
+  style::{Color, Modifier, Style},
+  widgets::{Block, Borders, List, ListItem, ListState, Paragraph},
+};
+use std::path::{Path, PathBuf};
+
+use crate::commands::services::{
+  create_jpa_one_to_one_relationship_service, get_all_jpa_entities_service,
+  get_jpa_entity_info_service,
+};
+use crate::common::types::cascade_type::CascadeType;
+use crate::common::types::mapping_type::MappingType;
+use crate::common::types::one_to_one_field_config::OneToOneFieldConfig;
+use crate::common::types::other_type::OtherType;
+use crate::ui::form_trait::{FormBehavior, FormState, InputMode, helpers};
+
+/// Entity type information
+#[derive(Debug, Clone)]
+struct EntityTypeInfo {
+  name: String,
+  package_name: String,
+}
+
+/// Represents which phase of the form we're in
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum FormPhase {
+  OwningConfiguration,
+  InverseConfiguration,
+}
+
+/// Represents which field is currently focused
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum FocusedField {
+  // Phase 1: Owning Configuration
+  MappingType,
+  TargetEntityType,
+  OwningFieldName,
+  OwningCascades,
+  OwningOther,
+
+  // Phase 2: Inverse Configuration (only for bidirectional)
+  InverseFieldName,
+  InverseCascades,
+  InverseOther,
+
+  // Navigation
+  BackButton,
+  NextButton,
+  ConfirmButton,
+}
+
+/// Parameters for static render functions
+struct RenderContext<'a> {
+  focused_field: FocusedField,
+  form_state: &'a FormState,
+}
+
+/// Parameters for selector rendering
+struct SelectorParams<'a> {
+  field: FocusedField,
+  title: &'a str,
+  selected_indices: &'a [usize],
+}
+
+/// Main form state for creating one-to-one relationships
+pub struct CreateOneToOneRelationshipForm {
+  // Common form state (embedded)
+  state: FormState,
+
+  // Current phase
+  phase: FormPhase,
+
+  // Field values
+  mapping_type_index: usize,
+  target_entity_index: Option<usize>,
+  owning_field_name: String,
+  inverse_field_name: String,
+
+  // Current entity information (owning side)
+  current_entity_name: String,
+  current_entity_package: String,
+
+  // Entity types available for selection (target entities - excludes current entity)
+  entity_types: Vec<EntityTypeInfo>,
+
+  // Cascade selections (indices of selected items)
+  owning_cascades: Vec<usize>,
+  inverse_cascades: Vec<usize>,
+
+  // Other options (indices of selected items)
+  owning_other: Vec<usize>,
+  inverse_other: Vec<usize>,
+
+  // List states
+  mapping_type_state: ListState,
+  entity_type_state: ListState,
+  owning_cascades_state: ListState,
+  inverse_cascades_state: ListState,
+  owning_other_state: ListState,
+  inverse_other_state: ListState,
+
+  // Text input cursors
+  owning_field_name_cursor: usize,
+  inverse_field_name_cursor: usize,
+
+  // Focus management
+  focused_field: FocusedField,
+
+  // Integration with syntaxpresso-core
+  cwd: PathBuf,
+  entity_file_b64_src: String,
+  entity_file_path: PathBuf,
+
+  // Navigation
+  should_go_back: bool,
+  back_pressed_once: bool,
+}
+
+impl CreateOneToOneRelationshipForm {
+  pub fn new(
+    cwd: PathBuf,
+    entity_file_b64_src: String,
+    entity_file_path: PathBuf,
+    _entity_files_json: String, // Not used anymore, we fetch directly
+  ) -> Self {
+    // Fetch current entity info
+    let (current_entity_name, current_entity_package) =
+      Self::fetch_current_entity_info(&entity_file_path, &entity_file_b64_src);
+
+    // Fetch all JPA entities and filter out the current one
+    let entity_types =
+      Self::fetch_target_entities(&cwd, &current_entity_name, &current_entity_package);
+
+    let mut mapping_type_state = ListState::default();
+    mapping_type_state.select(Some(0));
+
+    let mut entity_type_state = ListState::default();
+    entity_type_state.select(Some(0));
+
+    let mut owning_cascades_state = ListState::default();
+    owning_cascades_state.select(Some(0));
+
+    let mut inverse_cascades_state = ListState::default();
+    inverse_cascades_state.select(Some(0));
+
+    let mut owning_other_state = ListState::default();
+    owning_other_state.select(Some(0));
+
+    let mut inverse_other_state = ListState::default();
+    inverse_other_state.select(Some(0));
+
+    Self {
+      state: FormState::new(),
+      phase: FormPhase::OwningConfiguration,
+      mapping_type_index: 0,
+      target_entity_index: None,
+      owning_field_name: String::new(),
+      inverse_field_name: String::new(),
+      current_entity_name,
+      current_entity_package,
+      entity_types,
+      owning_cascades: Vec::new(),
+      inverse_cascades: Vec::new(),
+      owning_other: Vec::new(),
+      inverse_other: Vec::new(),
+      mapping_type_state,
+      entity_type_state,
+      owning_cascades_state,
+      inverse_cascades_state,
+      owning_other_state,
+      inverse_other_state,
+      owning_field_name_cursor: 0,
+      inverse_field_name_cursor: 0,
+      focused_field: FocusedField::MappingType,
+      cwd,
+      entity_file_b64_src,
+      entity_file_path,
+      should_go_back: false,
+      back_pressed_once: false,
+    }
+  }
+
+  /// Fetch current entity information
+  fn fetch_current_entity_info(
+    entity_file_path: &Path,
+    entity_file_b64_src: &str,
+  ) -> (String, String) {
+    match get_jpa_entity_info_service::run(Some(entity_file_path), Some(entity_file_b64_src)) {
+      Ok(entity_info) => (entity_info.entity_type, entity_info.entity_package_name),
+      Err(_) => {
+        // Fallback to unknown if service fails
+        ("Unknown".to_string(), "unknown".to_string())
+      }
+    }
+  }
+
+  /// Fetch all JPA entities and filter out the current entity
+  fn fetch_target_entities(
+    cwd: &Path,
+    current_entity_name: &str,
+    current_entity_package: &str,
+  ) -> Vec<EntityTypeInfo> {
+    match get_all_jpa_entities_service::run(cwd) {
+      Ok(entities) => {
+        entities
+          .into_iter()
+          .filter(|entity| {
+            // Exclude the current entity
+            !(entity.file_type == current_entity_name
+              && entity.file_package_name == current_entity_package)
+          })
+          .map(|entity| EntityTypeInfo {
+            name: entity.file_type,
+            package_name: entity.file_package_name,
+          })
+          .collect()
+      }
+      Err(_) => {
+        // Return empty list if service fails
+        Vec::new()
+      }
+    }
+  }
+
+  /// Parse entity files from JSON response (deprecated - kept for compatibility)
+  #[allow(dead_code)]
+  fn parse_entity_files(json_str: &str) -> Vec<EntityTypeInfo> {
+    let mut entity_types = Vec::new();
+
+    if let Ok(json) = serde_json::from_str::<serde_json::Value>(json_str) && let Some(data) = json.get("data") && let Some(files) = data.get("files").and_then(|f| f.as_array()) {
+      for file in files {
+        if let (Some(file_type), Some(package_name)) = (
+          file.get("fileType").and_then(|t| t.as_str()),
+          file.get("filePackageName").and_then(|p| p.as_str()),
+        ) {
+          entity_types.push(EntityTypeInfo {
+            name: file_type.to_string(),
+            package_name: package_name.to_string(),
+          });
+        }
+      }
+    }
+
+    entity_types
+  }
+
+  /// Auto-generate field name from entity type
+  fn auto_field_name(type_name: &str) -> String {
+    if type_name.is_empty() {
+      return String::new();
+    }
+    let mut chars = type_name.chars();
+    if let Some(first) = chars.next() {
+      format!("{}{}", first.to_lowercase(), chars.as_str())
+    } else {
+      String::new()
+    }
+  }
+
+  /// Update target entity and auto-fill field name
+  fn update_target_entity(&mut self) {
+    if let Some(idx) = self.entity_type_state.selected() {
+      self.target_entity_index = Some(idx);
+      if let Some(entity) = self.entity_types.get(idx) {
+        self.owning_field_name = Self::auto_field_name(&entity.name);
+        self.owning_field_name_cursor = self.owning_field_name.len();
+      }
+    }
+  }
+
+  /// Update mapping type
+  fn update_mapping_type(&mut self) {
+    if let Some(idx) = self.mapping_type_state.selected() {
+      self.mapping_type_index = idx;
+    }
+  }
+
+  /// Check if bidirectional mapping is selected
+  fn is_bidirectional(&self) -> bool {
+    self.mapping_type_index == 0
+  }
+
+  /// Get mapping type from index
+  fn get_mapping_type(&self) -> MappingType {
+    match self.mapping_type_index {
+      0 => MappingType::BidirectionalJoinColumn,
+      _ => MappingType::UnidirectionalJoinColumn,
+    }
+  }
+
+  /// Get cascade types from indices
+  fn get_cascade_types(indices: &[usize]) -> Vec<CascadeType> {
+    let all_cascades = Self::get_all_cascades();
+    indices.iter().filter_map(|&i| all_cascades.get(i).cloned()).collect()
+  }
+
+  /// Get other types from indices
+  fn get_other_types(indices: &[usize], is_owning: bool) -> Vec<OtherType> {
+    let all_others =
+      if is_owning { Self::get_owning_other_options() } else { Self::get_inverse_other_options() };
+    indices.iter().filter_map(|&i| all_others.get(i).cloned()).collect()
+  }
+
+  /// Get all cascade types
+  fn get_all_cascades() -> Vec<CascadeType> {
+    vec![
+      CascadeType::Persist,
+      CascadeType::Merge,
+      CascadeType::Remove,
+      CascadeType::Refresh,
+      CascadeType::Detach,
+    ]
+  }
+
+  /// Get owning side other options
+  fn get_owning_other_options() -> Vec<OtherType> {
+    vec![OtherType::Mandatory, OtherType::Unique, OtherType::OrphanRemoval]
+  }
+
+  /// Get inverse side other options
+  fn get_inverse_other_options() -> Vec<OtherType> {
+    vec![OtherType::Mandatory, OtherType::OrphanRemoval]
+  }
+
+  /// Toggle item in a list
+  fn toggle_in_list(list: &mut Vec<usize>, index: usize) {
+    if let Some(pos) = list.iter().position(|&i| i == index) {
+      list.remove(pos);
+    } else {
+      list.push(index);
+    }
+  }
+
+  /// Move focus to the next visible field
+  fn focus_next(&mut self) {
+    self.back_pressed_once = false;
+
+    self.focused_field = match self.phase {
+      FormPhase::OwningConfiguration => match self.focused_field {
+        FocusedField::MappingType => FocusedField::TargetEntityType,
+        FocusedField::TargetEntityType => FocusedField::OwningFieldName,
+        FocusedField::OwningFieldName => FocusedField::OwningCascades,
+        FocusedField::OwningCascades => FocusedField::OwningOther,
+        FocusedField::OwningOther => FocusedField::BackButton,
+        FocusedField::BackButton => {
+          if self.is_bidirectional() {
+            FocusedField::NextButton
+          } else {
+            FocusedField::ConfirmButton
+          }
+        }
+        FocusedField::NextButton => FocusedField::MappingType,
+        FocusedField::ConfirmButton => FocusedField::MappingType,
+        _ => FocusedField::MappingType,
+      },
+      FormPhase::InverseConfiguration => match self.focused_field {
+        FocusedField::InverseFieldName => FocusedField::InverseCascades,
+        FocusedField::InverseCascades => FocusedField::InverseOther,
+        FocusedField::InverseOther => FocusedField::BackButton,
+        FocusedField::BackButton => FocusedField::ConfirmButton,
+        FocusedField::ConfirmButton => FocusedField::InverseFieldName,
+        _ => FocusedField::InverseFieldName,
+      },
+    };
+  }
+
+  /// Move focus to the previous visible field
+  fn focus_prev(&mut self) {
+    self.back_pressed_once = false;
+
+    self.focused_field = match self.phase {
+      FormPhase::OwningConfiguration => match self.focused_field {
+        FocusedField::MappingType => {
+          if self.is_bidirectional() {
+            FocusedField::NextButton
+          } else {
+            FocusedField::ConfirmButton
+          }
+        }
+        FocusedField::TargetEntityType => FocusedField::MappingType,
+        FocusedField::OwningFieldName => FocusedField::TargetEntityType,
+        FocusedField::OwningCascades => FocusedField::OwningFieldName,
+        FocusedField::OwningOther => FocusedField::OwningCascades,
+        FocusedField::BackButton => FocusedField::OwningOther,
+        FocusedField::NextButton => FocusedField::BackButton,
+        FocusedField::ConfirmButton => FocusedField::BackButton,
+        _ => FocusedField::MappingType,
+      },
+      FormPhase::InverseConfiguration => match self.focused_field {
+        FocusedField::InverseFieldName => FocusedField::ConfirmButton,
+        FocusedField::InverseCascades => FocusedField::InverseFieldName,
+        FocusedField::InverseOther => FocusedField::InverseCascades,
+        FocusedField::BackButton => FocusedField::InverseOther,
+        FocusedField::ConfirmButton => FocusedField::BackButton,
+        _ => FocusedField::InverseFieldName,
+      },
+    };
+  }
+
+  /// Check if a field is hidden (not used anymore with phases, but kept for compatibility)
+  fn is_field_hidden(&self, _field: FocusedField) -> bool {
+    false
+  }
+
+  /// Called when entering insert mode
+  fn on_enter_insert_mode(&mut self, key: KeyCode) {
+    if key == KeyCode::Char('a') {
+      match self.focused_field {
+        FocusedField::OwningFieldName => {
+          self.owning_field_name_cursor = self.owning_field_name.len();
+        }
+        FocusedField::InverseFieldName => {
+          self.inverse_field_name_cursor = self.inverse_field_name.len();
+        }
+        _ => {}
+      }
+    }
+  }
+
+  /// Called when Enter is pressed in Normal mode
+  fn on_enter_pressed(&mut self) {
+    match self.focused_field {
+      FocusedField::NextButton => {
+        // Auto-generate inverse field name from current entity name
+        self.inverse_field_name = Self::auto_field_name(&self.current_entity_name);
+        self.inverse_field_name_cursor = self.inverse_field_name.len();
+
+        // Move to inverse configuration phase
+        self.phase = FormPhase::InverseConfiguration;
+        self.focused_field = FocusedField::InverseFieldName;
+        self.back_pressed_once = false;
+      }
+      FocusedField::ConfirmButton => {
+        self.execute_create_relationship();
+      }
+      FocusedField::BackButton => {
+        if self.back_pressed_once {
+          // If in inverse phase, go back to owning phase
+          if self.phase == FormPhase::InverseConfiguration {
+            self.phase = FormPhase::OwningConfiguration;
+            self.focused_field = FocusedField::MappingType;
+            self.back_pressed_once = false;
+          } else {
+            // If in owning phase, go back to parent form
+            self.should_go_back = true;
+          }
+        } else {
+          self.back_pressed_once = true;
+        }
+      }
+      _ => {}
+    }
+  }
+
+  /// Handle field-specific input in Insert mode
+  fn handle_field_insert(&mut self, key: KeyCode) {
+    match self.focused_field {
+      FocusedField::MappingType => self.handle_mapping_type_insert(key),
+      FocusedField::TargetEntityType => self.handle_entity_type_insert(key),
+      FocusedField::OwningFieldName => {
+        helpers::handle_text_input(
+          key,
+          &mut self.owning_field_name,
+          &mut self.owning_field_name_cursor,
+          &mut self.state.input_mode,
+        );
+      }
+      FocusedField::InverseFieldName => {
+        helpers::handle_text_input(
+          key,
+          &mut self.inverse_field_name,
+          &mut self.inverse_field_name_cursor,
+          &mut self.state.input_mode,
+        );
+      }
+      FocusedField::OwningCascades => self.handle_cascades_insert(key, true),
+      FocusedField::InverseCascades => self.handle_cascades_insert(key, false),
+      FocusedField::OwningOther => self.handle_other_insert(key, true),
+      FocusedField::InverseOther => self.handle_other_insert(key, false),
+      FocusedField::NextButton => {
+        if key == KeyCode::Enter {
+          // Auto-generate inverse field name from current entity name
+          self.inverse_field_name = Self::auto_field_name(&self.current_entity_name);
+          self.inverse_field_name_cursor = self.inverse_field_name.len();
+
+          self.phase = FormPhase::InverseConfiguration;
+          self.focused_field = FocusedField::InverseFieldName;
+          self.back_pressed_once = false;
+          self.state.input_mode = InputMode::Normal;
+        }
+      }
+      FocusedField::BackButton => {
+        if key == KeyCode::Enter {
+          if self.back_pressed_once {
+            if self.phase == FormPhase::InverseConfiguration {
+              self.phase = FormPhase::OwningConfiguration;
+              self.focused_field = FocusedField::MappingType;
+              self.back_pressed_once = false;
+              self.state.input_mode = InputMode::Normal;
+            } else {
+              self.should_go_back = true;
+            }
+          } else {
+            self.back_pressed_once = true;
+          }
+        }
+      }
+      FocusedField::ConfirmButton => {
+        if key == KeyCode::Enter {
+          self.execute_create_relationship();
+        }
+      }
+    }
+  }
+
+  fn handle_mapping_type_insert(&mut self, key: KeyCode) {
+    match key {
+      KeyCode::Char('j') | KeyCode::Down => {
+        helpers::navigate_list_static(&KeyCode::Down, &mut self.mapping_type_state, 2);
+        self.update_mapping_type();
+      }
+      KeyCode::Char('k') | KeyCode::Up => {
+        helpers::navigate_list_static(&KeyCode::Up, &mut self.mapping_type_state, 2);
+        self.update_mapping_type();
+      }
+      KeyCode::Enter => {
+        self.state.input_mode = InputMode::Normal;
+      }
+      _ => {}
+    }
+  }
+
+  fn handle_entity_type_insert(&mut self, key: KeyCode) {
+    match key {
+      KeyCode::Char('j') | KeyCode::Down => {
+        let len = self.entity_types.len();
+        helpers::navigate_list_static(&KeyCode::Down, &mut self.entity_type_state, len);
+        self.update_target_entity();
+      }
+      KeyCode::Char('k') | KeyCode::Up => {
+        let len = self.entity_types.len();
+        helpers::navigate_list_static(&KeyCode::Up, &mut self.entity_type_state, len);
+        self.update_target_entity();
+      }
+      KeyCode::Enter => {
+        self.state.input_mode = InputMode::Normal;
+      }
+      _ => {}
+    }
+  }
+
+  fn handle_cascades_insert(&mut self, key: KeyCode, is_owning: bool) {
+    let state =
+      if is_owning { &mut self.owning_cascades_state } else { &mut self.inverse_cascades_state };
+    let list = if is_owning { &mut self.owning_cascades } else { &mut self.inverse_cascades };
+
+    match key {
+      KeyCode::Char('j') | KeyCode::Down => {
+        let len = Self::get_all_cascades().len();
+        helpers::navigate_list_static(&KeyCode::Down, state, len);
+      }
+      KeyCode::Char('k') | KeyCode::Up => {
+        let len = Self::get_all_cascades().len();
+        helpers::navigate_list_static(&KeyCode::Up, state, len);
+      }
+      KeyCode::Char(' ') | KeyCode::Enter => {
+        if let Some(idx) = state.selected() {
+          Self::toggle_in_list(list, idx);
+        }
+        if key == KeyCode::Enter {
+          self.state.input_mode = InputMode::Normal;
+        }
+      }
+      _ => {}
+    }
+  }
+
+  fn handle_other_insert(&mut self, key: KeyCode, is_owning: bool) {
+    let state =
+      if is_owning { &mut self.owning_other_state } else { &mut self.inverse_other_state };
+    let list = if is_owning { &mut self.owning_other } else { &mut self.inverse_other };
+    let len = if is_owning {
+      Self::get_owning_other_options().len()
+    } else {
+      Self::get_inverse_other_options().len()
+    };
+
+    match key {
+      KeyCode::Char('j') | KeyCode::Down => {
+        helpers::navigate_list_static(&KeyCode::Down, state, len);
+      }
+      KeyCode::Char('k') | KeyCode::Up => {
+        helpers::navigate_list_static(&KeyCode::Up, state, len);
+      }
+      KeyCode::Char(' ') | KeyCode::Enter => {
+        if let Some(idx) = state.selected() {
+          Self::toggle_in_list(list, idx);
+        }
+        if key == KeyCode::Enter {
+          self.state.input_mode = InputMode::Normal;
+        }
+      }
+      _ => {}
+    }
+  }
+
+  fn execute_create_relationship(&mut self) {
+    // Validate
+    let target_entity_name = match self.target_entity_index {
+      Some(idx) => match self.entity_types.get(idx) {
+        Some(entity) => entity.name.clone(),
+        None => {
+          self.state.error_message = Some("No target entity selected".to_string());
+          return;
+        }
+      },
+      None => {
+        self.state.error_message = Some("Target entity type is required".to_string());
+        return;
+      }
+    };
+
+    if self.owning_field_name.is_empty() {
+      self.state.error_message = Some("Owning side field name is required".to_string());
+      return;
+    }
+
+    if self.is_bidirectional() && self.inverse_field_name.is_empty() {
+      self.state.error_message =
+        Some("Inverse side field name is required for bidirectional relationships".to_string());
+      return;
+    }
+
+    // Build field config
+    let field_config = OneToOneFieldConfig {
+      inverse_field_type: target_entity_name,
+      mapping_type: Some(self.get_mapping_type()),
+      owning_side_cascades: Self::get_cascade_types(&self.owning_cascades),
+      inverse_side_cascades: Self::get_cascade_types(&self.inverse_cascades),
+      owning_side_other: Self::get_other_types(&self.owning_other, true),
+      inverse_side_other: Self::get_other_types(&self.inverse_other, false),
+    };
+
+    // Call service
+    match create_jpa_one_to_one_relationship_service::run(
+      &self.cwd,
+      &self.entity_file_b64_src,
+      &self.entity_file_path,
+      &self.owning_field_name,
+      &self.inverse_field_name,
+      &field_config,
+    ) {
+      Ok(responses) => {
+        eprintln!("Successfully created one-to-one relationship in {} file(s)", responses.len());
+        for response in responses {
+          eprintln!(
+            "  - {} in {} at {}",
+            response.file_type, response.file_package_name, response.file_path
+          );
+        }
+        self.state.should_quit = true;
+        std::process::exit(0);
+      }
+      Err(e) => {
+        self.state.error_message = Some(format!("Error: {}", e));
+      }
+    }
+  }
+
+  /// Check if user wants to go back
+  pub fn should_go_back(&self) -> bool {
+    self.should_go_back
+  }
+
+  // Render methods
+  fn render_title_bar(&self, frame: &mut Frame, area: Rect) {
+    let title_text = "Create new JPA Entity One-to-One Relationship";
+    let title = Paragraph::new(title_text)
+      .alignment(Alignment::Center)
+      .style(Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD))
+      .block(Block::default().borders(Borders::BOTTOM));
+    frame.render_widget(title, area);
+  }
+
+  fn render_mapping_type_selector(&mut self, frame: &mut Frame, area: Rect) {
+    let is_focused = self.focused_field == FocusedField::MappingType;
+
+    let mapping_types = ["Bidirectional (Recommended)", "Unidirectional with Join Column"];
+    let items: Vec<ListItem> = mapping_types
+      .iter()
+      .enumerate()
+      .map(|(i, name)| {
+        let is_selected = self.mapping_type_state.selected() == Some(i);
+        let prefix = if is_selected { "●" } else { "○" };
+        ListItem::new(format!(" {} {}", prefix, name))
+      })
+      .collect();
+
+    let border_style =
+      if is_focused { Style::default().fg(Color::Yellow) } else { Style::default() };
+
+    let title = self.generate_title("Mapping Type", is_focused);
+    let list = List::new(items)
+      .block(Block::default().title(title).borders(Borders::ALL).border_style(border_style))
+      .highlight_style(Style::default().bg(Color::DarkGray).add_modifier(Modifier::BOLD))
+      .highlight_symbol(">> ");
+
+    frame.render_stateful_widget(list, area, &mut self.mapping_type_state);
+  }
+
+  fn render_entity_type_selector(&mut self, frame: &mut Frame, area: Rect) {
+    let is_focused = self.focused_field == FocusedField::TargetEntityType;
+
+    let items: Vec<ListItem> = self
+      .entity_types
+      .iter()
+      .enumerate()
+      .map(|(i, entity)| {
+        let is_selected = self.entity_type_state.selected() == Some(i);
+        let prefix = if is_selected { "●" } else { "○" };
+        ListItem::new(format!(" {} {} ({})", prefix, entity.name, entity.package_name))
+      })
+      .collect();
+
+    let border_style =
+      if is_focused { Style::default().fg(Color::Yellow) } else { Style::default() };
+
+    let title = self.generate_title("Target Entity Type", is_focused);
+    let list = List::new(items)
+      .block(Block::default().title(title).borders(Borders::ALL).border_style(border_style))
+      .highlight_style(Style::default().bg(Color::DarkGray).add_modifier(Modifier::BOLD))
+      .highlight_symbol(">> ");
+
+    frame.render_stateful_widget(list, area, &mut self.entity_type_state);
+  }
+
+  fn render_text_input(
+    &self,
+    frame: &mut Frame,
+    area: Rect,
+    field: FocusedField,
+    title: &str,
+    text: &str,
+    cursor: usize,
+  ) {
+    if self.is_field_hidden(field) {
+      return;
+    }
+
+    let is_focused = self.focused_field == field;
+    let border_style =
+      if is_focused { Style::default().fg(Color::Yellow) } else { Style::default() };
+
+    let title = self.generate_title(title, is_focused);
+    let input = Paragraph::new(text)
+      .block(Block::default().title(title).borders(Borders::ALL).border_style(border_style));
+    frame.render_widget(input, area);
+
+    if is_focused && self.state.input_mode == InputMode::Insert {
+      frame.set_cursor_position((area.x + cursor as u16 + 1, area.y + 1));
+    }
+  }
+
+  #[allow(clippy::too_many_arguments)]
+  fn render_cascade_selector(
+    &self,
+    frame: &mut Frame,
+    area: Rect,
+    field: FocusedField,
+    title: &str,
+    selected_indices: &[usize],
+    state: &mut ListState,
+  ) {
+    let ctx = RenderContext { focused_field: self.focused_field, form_state: &self.state };
+    let params = SelectorParams { field, title, selected_indices };
+    Self::render_cascade_selector_static(frame, area, state, &params, &ctx)
+  }
+
+  fn render_cascade_selector_static(
+    frame: &mut Frame,
+    area: Rect,
+    state: &mut ListState,
+    params: &SelectorParams,
+    ctx: &RenderContext,
+  ) {
+    // Check if field is hidden based on inverse_fields_hidden
+    let is_inverse = matches!(params.field, FocusedField::InverseCascades);
+    if is_inverse
+      && (matches!(ctx.focused_field, FocusedField::MappingType)
+        && ctx.form_state.input_mode != InputMode::Normal)
+    {
+      // This is a simplified check - in practice we'd need inverse_fields_hidden
+      // For now, we'll just render it
+    }
+
+    let is_focused = ctx.focused_field == params.field;
+    let cascades = Self::get_all_cascades();
+
+    let items: Vec<ListItem> = cascades
+      .iter()
+      .enumerate()
+      .map(|(i, cascade)| {
+        let is_selected = params.selected_indices.contains(&i);
+        let checkbox = if is_selected { "[x]" } else { "[ ]" };
+        ListItem::new(format!(" {} {}", checkbox, cascade.as_str()))
+      })
+      .collect();
+
+    let border_style =
+      if is_focused { Style::default().fg(Color::Yellow) } else { Style::default() };
+
+    let title_text = if is_focused && ctx.form_state.input_mode == InputMode::Insert {
+      format!("{} [INSERT]", params.title)
+    } else {
+      params.title.to_string()
+    };
+
+    let list = List::new(items)
+      .block(Block::default().title(title_text).borders(Borders::ALL).border_style(border_style))
+      .highlight_style(Style::default().bg(Color::DarkGray).add_modifier(Modifier::BOLD))
+      .highlight_symbol(">> ");
+
+    frame.render_stateful_widget(list, area, state);
+  }
+
+  #[allow(clippy::too_many_arguments)]
+  fn render_other_selector(
+    &self,
+    frame: &mut Frame,
+    area: Rect,
+    field: FocusedField,
+    title: &str,
+    selected_indices: &[usize],
+    state: &mut ListState,
+    is_owning: bool,
+  ) {
+    let ctx = RenderContext { focused_field: self.focused_field, form_state: &self.state };
+    let params = SelectorParams { field, title, selected_indices };
+    Self::render_other_selector_static(frame, area, state, &params, is_owning, &ctx)
+  }
+
+  fn render_other_selector_static(
+    frame: &mut Frame,
+    area: Rect,
+    state: &mut ListState,
+    params: &SelectorParams,
+    is_owning: bool,
+    ctx: &RenderContext,
+  ) {
+    let is_focused = ctx.focused_field == params.field;
+    let options =
+      if is_owning { Self::get_owning_other_options() } else { Self::get_inverse_other_options() };
+
+    let items: Vec<ListItem> = options
+      .iter()
+      .enumerate()
+      .map(|(i, other)| {
+        let is_selected = params.selected_indices.contains(&i);
+        let checkbox = if is_selected { "[x]" } else { "[ ]" };
+        let display = match other {
+          OtherType::Mandatory => "Mandatory",
+          OtherType::Unique => "Unique",
+          OtherType::OrphanRemoval => "Orphan Removal",
+          OtherType::LargeObject => "Large Object",
+          OtherType::EqualsHashcode => "Equals/Hashcode",
+          OtherType::Mutable => "Mutable",
+        };
+        ListItem::new(format!(" {} {}", checkbox, display))
+      })
+      .collect();
+
+    let border_style =
+      if is_focused { Style::default().fg(Color::Yellow) } else { Style::default() };
+
+    let title_text = if is_focused && ctx.form_state.input_mode == InputMode::Insert {
+      format!("{} [INSERT]", params.title)
+    } else {
+      params.title.to_string()
+    };
+
+    let list = List::new(items)
+      .block(Block::default().title(title_text).borders(Borders::ALL).border_style(border_style))
+      .highlight_style(Style::default().bg(Color::DarkGray).add_modifier(Modifier::BOLD))
+      .highlight_symbol(">> ");
+
+    frame.render_stateful_widget(list, area, state);
+  }
+
+  fn render_owning_phase_buttons(&self, frame: &mut Frame, area: Rect) {
+    let chunks = Layout::default()
+      .direction(Direction::Horizontal)
+      .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+      .split(area);
+
+    // Render Back button
+    let is_back_focused = self.focused_field == FocusedField::BackButton;
+    let back_color = if self.back_pressed_once { Color::Red } else { Color::Yellow };
+    let back_text = if self.back_pressed_once { "Press again to go back" } else { "Back" };
+    let back_style = if is_back_focused {
+      Style::default().bg(back_color).fg(Color::Black).add_modifier(Modifier::BOLD)
+    } else {
+      Style::default().fg(back_color)
+    };
+    let back_button = Paragraph::new(format!("[ {} ]", back_text))
+      .alignment(Alignment::Center)
+      .style(back_style)
+      .block(Block::default().borders(Borders::empty()));
+    frame.render_widget(back_button, chunks[0]);
+
+    // Render Next/Confirm button depending on mapping type
+    if self.is_bidirectional() {
+      // Show Next button for bidirectional
+      let is_next_focused = self.focused_field == FocusedField::NextButton;
+      let next_style = if is_next_focused {
+        Style::default().bg(Color::Green).fg(Color::Black).add_modifier(Modifier::BOLD)
+      } else {
+        Style::default().fg(Color::Green)
+      };
+      let next_button = Paragraph::new("[ Next -> ]")
+        .alignment(Alignment::Center)
+        .style(next_style)
+        .block(Block::default().borders(Borders::empty()));
+      frame.render_widget(next_button, chunks[1]);
+    } else {
+      // Show Confirm button for unidirectional
+      let is_confirm_focused = self.focused_field == FocusedField::ConfirmButton;
+      let color = match self.state.escape_handler.pressed_once {
+        true => Color::Red,
+        false => Color::Green,
+      };
+      let text = match self.state.escape_handler.pressed_once {
+        true => "Press esc again to close or any key to return",
+        false => "Confirm",
+      };
+      let confirm_style = if is_confirm_focused {
+        Style::default().bg(color).fg(Color::Black).add_modifier(Modifier::BOLD)
+      } else {
+        Style::default().fg(color)
+      };
+      let confirm_button = Paragraph::new(format!("[ {} ]", text))
+        .alignment(Alignment::Center)
+        .style(confirm_style)
+        .block(Block::default().borders(Borders::empty()));
+      frame.render_widget(confirm_button, chunks[1]);
+    }
+  }
+
+  fn render_buttons(&self, frame: &mut Frame, area: Rect) {
+    let chunks = Layout::default()
+      .direction(Direction::Horizontal)
+      .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+      .split(area);
+
+    // Render Back button
+    let is_back_focused = self.focused_field == FocusedField::BackButton;
+    let back_color = if self.back_pressed_once { Color::Red } else { Color::Yellow };
+    let back_text = if self.back_pressed_once { "Press again to go back" } else { "Back" };
+    let back_style = if is_back_focused {
+      Style::default().bg(back_color).fg(Color::Black).add_modifier(Modifier::BOLD)
+    } else {
+      Style::default().fg(back_color)
+    };
+    let back_button = Paragraph::new(format!("[ {} ]", back_text))
+      .alignment(Alignment::Center)
+      .style(back_style)
+      .block(Block::default().borders(Borders::empty()));
+    frame.render_widget(back_button, chunks[0]);
+
+    // Render Confirm button
+    let is_confirm_focused = self.focused_field == FocusedField::ConfirmButton;
+    let color = match self.state.escape_handler.pressed_once {
+      true => Color::Red,
+      false => Color::Green,
+    };
+    let text = match self.state.escape_handler.pressed_once {
+      true => "Press esc again to close or any key to return",
+      false => "Confirm",
+    };
+    let confirm_style = if is_confirm_focused {
+      Style::default().bg(color).fg(Color::Black).add_modifier(Modifier::BOLD)
+    } else {
+      Style::default().fg(color)
+    };
+    let confirm_button = Paragraph::new(format!("[ {} ]", text))
+      .alignment(Alignment::Center)
+      .style(confirm_style)
+      .block(Block::default().borders(Borders::empty()));
+    frame.render_widget(confirm_button, chunks[1]);
+  }
+
+  pub fn render(&mut self, frame: &mut Frame) {
+    match self.phase {
+      FormPhase::OwningConfiguration => self.render_owning_phase(frame),
+      FormPhase::InverseConfiguration => self.render_inverse_phase(frame),
+    }
+  }
+
+  fn render_owning_phase(&mut self, frame: &mut Frame) {
+    let area = frame.area();
+
+    let constraints = vec![
+      Constraint::Length(2), // Title
+      Constraint::Length(4), // Mapping type
+      Constraint::Length(9), // Entity type
+      Constraint::Length(3), // Owning field name
+      Constraint::Length(7), // Owning cascades
+      Constraint::Length(5), // Owning other
+      Constraint::Min(0),    // Errors
+      Constraint::Length(1), // Buttons
+    ];
+
+    let chunks =
+      Layout::default().direction(Direction::Vertical).constraints(constraints).split(area);
+
+    let mut idx = 0;
+
+    // Title
+    let title_text = "Create JPA One-to-One Relationship - Step 1: Owning Side";
+    let title = Paragraph::new(title_text)
+      .alignment(Alignment::Center)
+      .style(Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD))
+      .block(Block::default().borders(Borders::BOTTOM));
+    frame.render_widget(title, chunks[idx]);
+    idx += 1;
+
+    self.render_mapping_type_selector(frame, chunks[idx]);
+    idx += 1;
+
+    self.render_entity_type_selector(frame, chunks[idx]);
+    idx += 1;
+
+    self.render_text_input(
+      frame,
+      chunks[idx],
+      FocusedField::OwningFieldName,
+      "Owning Side Field Name",
+      &self.owning_field_name,
+      self.owning_field_name_cursor,
+    );
+    idx += 1;
+
+    // Render cascade selectors
+    {
+      let owning_cascades = &self.owning_cascades;
+      let owning_cascades_state = &mut self.owning_cascades_state;
+      let ctx = RenderContext { focused_field: self.focused_field, form_state: &self.state };
+      let params = SelectorParams {
+        field: FocusedField::OwningCascades,
+        title: "Owning Side Cascade Types (Space to toggle)",
+        selected_indices: owning_cascades,
+      };
+      Self::render_cascade_selector_static(
+        frame,
+        chunks[idx],
+        owning_cascades_state,
+        &params,
+        &ctx,
+      );
+    }
+    idx += 1;
+
+    {
+      let owning_other = &self.owning_other;
+      let owning_other_state = &mut self.owning_other_state;
+      let ctx = RenderContext { focused_field: self.focused_field, form_state: &self.state };
+      let params = SelectorParams {
+        field: FocusedField::OwningOther,
+        title: "Owning Side Options (Space to toggle)",
+        selected_indices: owning_other,
+      };
+      Self::render_other_selector_static(
+        frame,
+        chunks[idx],
+        owning_other_state,
+        &params,
+        true,
+        &ctx,
+      );
+    }
+    idx += 1;
+
+    // Render error if present
+    if let Some(ref error_msg) = self.state.error_message {
+      let error_paragraph =
+        Paragraph::new(error_msg.as_str()).style(Style::default().fg(Color::Red)).block(
+          Block::default()
+            .title("Error")
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(Color::Red)),
+        );
+      frame.render_widget(error_paragraph, chunks[idx]);
+    }
+    idx += 1;
+
+    self.render_owning_phase_buttons(frame, chunks[idx]);
+  }
+
+  fn render_inverse_phase(&mut self, frame: &mut Frame) {
+    let area = frame.area();
+
+    let constraints = vec![
+      Constraint::Length(2), // Title
+      Constraint::Length(3), // Inverse field name
+      Constraint::Length(7), // Inverse cascades
+      Constraint::Length(4), // Inverse other
+      Constraint::Min(0),    // Errors
+      Constraint::Length(1), // Buttons
+    ];
+
+    let chunks =
+      Layout::default().direction(Direction::Vertical).constraints(constraints).split(area);
+
+    let mut idx = 0;
+
+    // Title
+    let title_text = "Create JPA One-to-One Relationship - Step 2: Inverse Side";
+    let title = Paragraph::new(title_text)
+      .alignment(Alignment::Center)
+      .style(Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD))
+      .block(Block::default().borders(Borders::BOTTOM));
+    frame.render_widget(title, chunks[idx]);
+    idx += 1;
+
+    self.render_text_input(
+      frame,
+      chunks[idx],
+      FocusedField::InverseFieldName,
+      "Inverse Side Field Name",
+      &self.inverse_field_name,
+      self.inverse_field_name_cursor,
+    );
+    idx += 1;
+
+    // Render cascade selectors
+    {
+      let inverse_cascades = &self.inverse_cascades;
+      let inverse_cascades_state = &mut self.inverse_cascades_state;
+      let ctx = RenderContext { focused_field: self.focused_field, form_state: &self.state };
+      let params = SelectorParams {
+        field: FocusedField::InverseCascades,
+        title: "Inverse Side Cascade Types (Space to toggle)",
+        selected_indices: inverse_cascades,
+      };
+      Self::render_cascade_selector_static(
+        frame,
+        chunks[idx],
+        inverse_cascades_state,
+        &params,
+        &ctx,
+      );
+    }
+    idx += 1;
+
+    {
+      let inverse_other = &self.inverse_other;
+      let inverse_other_state = &mut self.inverse_other_state;
+      let ctx = RenderContext { focused_field: self.focused_field, form_state: &self.state };
+      let params = SelectorParams {
+        field: FocusedField::InverseOther,
+        title: "Inverse Side Options (Space to toggle)",
+        selected_indices: inverse_other,
+      };
+      Self::render_other_selector_static(
+        frame,
+        chunks[idx],
+        inverse_other_state,
+        &params,
+        false,
+        &ctx,
+      );
+    }
+    idx += 1;
+
+    // Render error if present
+    if let Some(ref error_msg) = self.state.error_message {
+      let error_paragraph =
+        Paragraph::new(error_msg.as_str()).style(Style::default().fg(Color::Red)).block(
+          Block::default()
+            .title("Error")
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(Color::Red)),
+        );
+      frame.render_widget(error_paragraph, chunks[idx]);
+    }
+    idx += 1;
+
+    self.render_buttons(frame, chunks[idx]);
+  }
+}
+
+// Implement the FormBehavior trait
+impl FormBehavior for CreateOneToOneRelationshipForm {
+  fn form_state(&self) -> &FormState {
+    &self.state
+  }
+
+  fn form_state_mut(&mut self) -> &mut FormState {
+    &mut self.state
+  }
+
+  fn focus_next(&mut self) {
+    CreateOneToOneRelationshipForm::focus_next(self)
+  }
+
+  fn focus_prev(&mut self) {
+    CreateOneToOneRelationshipForm::focus_prev(self)
+  }
+
+  fn on_enter_insert_mode(&mut self, key: KeyCode) {
+    CreateOneToOneRelationshipForm::on_enter_insert_mode(self, key)
+  }
+
+  fn on_enter_pressed(&mut self) {
+    CreateOneToOneRelationshipForm::on_enter_pressed(self)
+  }
+
+  fn handle_field_insert(&mut self, key: KeyCode) {
+    CreateOneToOneRelationshipForm::handle_field_insert(self, key)
+  }
+
+  fn render(&mut self, frame: &mut Frame) {
+    CreateOneToOneRelationshipForm::render(self, frame)
+  }
+}

--- a/src/ui/forms/mod.rs
+++ b/src/ui/forms/mod.rs
@@ -1,0 +1,14 @@
+pub mod create_basic_field;
+pub mod create_entity_field;
+pub mod create_entity_relationship;
+pub mod create_enum_field;
+pub mod create_id_field;
+pub mod create_java_file;
+pub mod create_jpa_entity;
+pub mod create_many_to_one_relationship;
+pub mod create_one_to_one_relationship;
+
+pub use create_entity_field::CreateEntityFieldForm;
+pub use create_entity_relationship::CreateEntityRelationshipForm;
+pub use create_java_file::CreateJavaFileForm;
+pub use create_jpa_entity::CreateJpaEntityForm;

--- a/src/ui/forms/mod.rs
+++ b/src/ui/forms/mod.rs
@@ -5,6 +5,7 @@ pub mod create_enum_field;
 pub mod create_id_field;
 pub mod create_java_file;
 pub mod create_jpa_entity;
+pub mod create_jpa_repository;
 pub mod create_many_to_one_relationship;
 pub mod create_one_to_one_relationship;
 
@@ -12,3 +13,4 @@ pub use create_entity_field::CreateEntityFieldForm;
 pub use create_entity_relationship::CreateEntityRelationshipForm;
 pub use create_java_file::CreateJavaFileForm;
 pub use create_jpa_entity::CreateJpaEntityForm;
+pub use create_jpa_repository::CreateJpaRepositoryForm;

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,0 +1,13 @@
+#[cfg(feature = "ui")]
+pub mod form_trait;
+#[cfg(feature = "ui")]
+pub mod forms;
+#[cfg(feature = "ui")]
+pub mod runner;
+#[cfg(feature = "ui")]
+pub mod widgets;
+
+#[cfg(feature = "ui")]
+pub use form_trait::FormBehavior;
+#[cfg(feature = "ui")]
+pub use runner::run_ui_command;

--- a/src/ui/runner.rs
+++ b/src/ui/runner.rs
@@ -40,7 +40,9 @@ fn run_app<B: ratatui::backend::Backend, F: FormBehavior>(
   loop {
     terminal.draw(|f| app.render(f))?;
 
-    if let Event::Key(key) = event::read()? && key.kind == KeyEventKind::Press {
+    if let Event::Key(key) = event::read()?
+      && key.kind == KeyEventKind::Press
+    {
       if key.code == KeyCode::Char('c') && key.modifiers.contains(KeyModifiers::CONTROL) {
         if app.handle_input(KeyCode::Char('c')) {
           return Ok(());

--- a/src/ui/runner.rs
+++ b/src/ui/runner.rs
@@ -1,0 +1,56 @@
+use crossterm::{
+  event::{
+    self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEventKind, KeyModifiers,
+  },
+  execute,
+  terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
+};
+use ratatui::{Terminal, backend::CrosstermBackend};
+use std::{error::Error, io};
+
+use super::form_trait::FormBehavior;
+
+pub fn run_ui_command<F: FormBehavior>(mut form: F) -> Result<(), Box<dyn Error>> {
+  // Setup terminal
+  enable_raw_mode()?;
+  let mut stdout = io::stdout();
+  execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
+  let backend = CrosstermBackend::new(stdout);
+  let mut terminal = Terminal::new(backend)?;
+
+  // Run the app
+  let res = run_app(&mut terminal, &mut form);
+
+  // Restore terminal
+  disable_raw_mode()?;
+  execute!(terminal.backend_mut(), LeaveAlternateScreen, DisableMouseCapture)?;
+  terminal.show_cursor()?;
+
+  if let Err(err) = res {
+    println!("{err:?}");
+  }
+
+  Ok(())
+}
+
+fn run_app<B: ratatui::backend::Backend, F: FormBehavior>(
+  terminal: &mut Terminal<B>,
+  app: &mut F,
+) -> io::Result<()> {
+  loop {
+    terminal.draw(|f| app.render(f))?;
+
+    if let Event::Key(key) = event::read()? && key.kind == KeyEventKind::Press {
+      if key.code == KeyCode::Char('c') && key.modifiers.contains(KeyModifiers::CONTROL) {
+        if app.handle_input(KeyCode::Char('c')) {
+          return Ok(());
+        }
+        continue;
+      }
+
+      if app.handle_input(key.code) {
+        return Ok(());
+      }
+    }
+  }
+}

--- a/src/ui/widgets.rs
+++ b/src/ui/widgets.rs
@@ -1,0 +1,216 @@
+#![allow(dead_code)]
+
+use crossterm::event::KeyCode;
+use ratatui::{
+  Frame,
+  layout::{Alignment, Rect},
+  style::{Color, Modifier, Style},
+  widgets::{Block, Borders, List, ListItem, ListState, Paragraph},
+};
+
+use crate::ui::form_trait::InputMode;
+
+/// Generic text input widget with cursor
+pub struct TextInput {
+  pub value: String,
+  pub cursor: usize,
+  pub label: String,
+}
+
+impl TextInput {
+  pub fn new(label: impl Into<String>, default_value: impl Into<String>) -> Self {
+    let value = default_value.into();
+    let cursor = value.len();
+    Self { value, cursor, label: label.into() }
+  }
+
+  pub fn handle_input(&mut self, key: KeyCode) {
+    match key {
+      KeyCode::Char(c) => {
+        self.value.insert(self.cursor, c);
+        self.cursor += 1;
+      }
+      KeyCode::Backspace => {
+        if self.cursor > 0 {
+          self.value.remove(self.cursor - 1);
+          self.cursor -= 1;
+        }
+      }
+      KeyCode::Delete => {
+        if self.cursor < self.value.len() {
+          self.value.remove(self.cursor);
+        }
+      }
+      KeyCode::Left => {
+        if self.cursor > 0 {
+          self.cursor -= 1;
+        }
+      }
+      KeyCode::Right => {
+        if self.cursor < self.value.len() {
+          self.cursor += 1;
+        }
+      }
+      KeyCode::Home => {
+        self.cursor = 0;
+      }
+      KeyCode::End => {
+        self.cursor = self.value.len();
+      }
+      _ => {}
+    }
+  }
+
+  pub fn render(&self, frame: &mut Frame, area: Rect, is_focused: bool, input_mode: InputMode) {
+    let border_style =
+      if is_focused { Style::default().fg(Color::Yellow) } else { Style::default() };
+
+    let title = if is_focused && input_mode == InputMode::Insert {
+      format!("{} -- INSERT --", self.label)
+    } else if is_focused {
+      format!("{} -- NORMAL --", self.label)
+    } else {
+      self.label.clone()
+    };
+
+    let input = Paragraph::new(self.value.as_str())
+      .block(Block::default().title(title).borders(Borders::ALL).border_style(border_style));
+
+    frame.render_widget(input, area);
+
+    // Show cursor if focused and in insert mode
+    if is_focused && input_mode == InputMode::Insert {
+      frame.set_cursor_position((area.x + self.cursor as u16 + 1, area.y + 1));
+    }
+  }
+}
+
+/// Generic list selector widget
+pub struct ListSelector {
+  pub options: Vec<String>,
+  pub state: ListState,
+  pub label: String,
+}
+
+impl ListSelector {
+  pub fn new(label: impl Into<String>, options: Vec<String>) -> Self {
+    let mut state = ListState::default();
+    state.select(Some(0));
+    Self { options, state, label: label.into() }
+  }
+
+  pub fn handle_input(&mut self, key: KeyCode) {
+    let len = self.options.len();
+    let i = match self.state.selected() {
+      Some(i) => match key {
+        KeyCode::Up | KeyCode::Char('k') => {
+          if i == 0 {
+            len - 1
+          } else {
+            i - 1
+          }
+        }
+        KeyCode::Down | KeyCode::Char('j') => {
+          if i >= len - 1 {
+            0
+          } else {
+            i + 1
+          }
+        }
+        _ => i,
+      },
+      None => 0,
+    };
+    self.state.select(Some(i));
+  }
+
+  pub fn selected_value(&self) -> Option<&String> {
+    self.state.selected().and_then(|i| self.options.get(i))
+  }
+
+  pub fn selected_index(&self) -> Option<usize> {
+    self.state.selected()
+  }
+
+  pub fn render(&mut self, frame: &mut Frame, area: Rect, is_focused: bool, input_mode: InputMode) {
+    let items: Vec<ListItem> = self
+      .options
+      .iter()
+      .enumerate()
+      .map(|(i, opt)| {
+        let is_selected = self.state.selected() == Some(i);
+        let prefix = if is_selected { "●" } else { "○" };
+        ListItem::new(format!(" {} {}", prefix, opt))
+      })
+      .collect();
+
+    let border_style =
+      if is_focused { Style::default().fg(Color::Yellow) } else { Style::default() };
+
+    let title = if is_focused && input_mode == InputMode::Insert {
+      format!("{} -- INSERT --", self.label)
+    } else if is_focused {
+      format!("{} -- NORMAL --", self.label)
+    } else {
+      self.label.clone()
+    };
+
+    let list = List::new(items)
+      .block(Block::default().title(title).borders(Borders::ALL).border_style(border_style))
+      .highlight_style(Style::default().bg(Color::DarkGray).add_modifier(Modifier::BOLD))
+      .highlight_symbol(">> ");
+
+    frame.render_stateful_widget(list, area, &mut self.state);
+  }
+}
+
+/// Generic button widget
+pub struct Button {
+  pub label: String,
+  pub color: Color,
+}
+
+impl Button {
+  pub fn new(label: impl Into<String>) -> Self {
+    Self { label: label.into(), color: Color::Green }
+  }
+
+  pub fn with_color(mut self, color: Color) -> Self {
+    self.color = color;
+    self
+  }
+
+  pub fn render(&self, frame: &mut Frame, area: Rect, is_focused: bool) {
+    let style = if is_focused {
+      Style::default().bg(self.color).fg(Color::Black).add_modifier(Modifier::BOLD)
+    } else {
+      Style::default().fg(self.color)
+    };
+
+    let button = Paragraph::new(format!("[ {} ]", self.label))
+      .alignment(Alignment::Center)
+      .style(style)
+      .block(Block::default().borders(Borders::empty()));
+
+    frame.render_widget(button, area);
+  }
+}
+
+/// Title bar widget
+pub struct TitleBar {
+  pub title: String,
+}
+
+impl TitleBar {
+  pub fn new(title: impl Into<String>) -> Self {
+    Self { title: title.into() }
+  }
+
+  pub fn render(&self, frame: &mut Frame, area: Rect) {
+    let title = Paragraph::new(self.title.as_str())
+      .alignment(Alignment::Center)
+      .style(Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD))
+      .block(Block::default().borders(Borders::BOTTOM));
+    frame.render_widget(title, area);
+  }
+}


### PR DESCRIPTION
## Summary

This PR merges the `implement-rust-ui` branch into `develop`, introducing a comprehensive terminal UI (TUI) for interactive Java code generation, expanding the architecture to support both CLI and TUI workflows, and improving the modularity, usability, and documentation of the Syntaxpresso Core project.

## Changes

- **Terminal UI (TUI) Feature:**
  - Added a new UI-enabled binary variant, built with a `ui` feature flag, providing interactive terminal forms for Java file and JPA entity/repository/field/relationship creation.
  - Integrated `ratatui` and `crossterm` as optional dependencies for TUI support.
  - Implemented `UiCommands` enum and subcommands, feature-gated for UI builds, with explicit command mapping and argument validation.
  - Developed reusable TUI form components and navigation logic, including `FormBehavior` trait and `FormState`.
  - Added interactive forms for creating Java files, JPA entities, basic fields, entity relationships, and repositories.
  - Standardized UI form output to emit JSON responses consistent with CLI commands.

- **Command and Service Layer Enhancements:**
  - Refactored command and service signatures to improve clarity and reliability, including extracting entity names from file paths and supporting manual ID entry for JPA repositories.
  - Added `execute_with_manual_id` for repository creation when automatic ID detection fails.
  - Updated file save logic to use a new `save_to_existing_file` method for trusted file overwrites, bypassing unnecessary path validation for user-opened files.
  - Improved error handling, modularity, and code formatting across command and service modules.

- **Response and API Improvements:**
  - Introduced new response types for entity field and many-to-one relationship creation.
  - Unified response output and error handling for both CLI and UI workflows.

- **Documentation and Developer Experience:**
  - Significantly expanded the `README.md`:
    - Documented dual-interface architecture (CLI and TUI), request/response model, and process flow.
    - Added detailed instructions for building, running, and testing both binary variants.
    - Provided local development setup for Neovim plugin integration and standalone UI testing.
    - Clarified available commands, feature flags, and binary naming conventions.
    - Included keyboard shortcuts and usage tips for the interactive UI.
  - Updated release workflow to build and package both CLI-only and UI-enabled binaries for all supported platforms, with clear artifact naming and permissions.
  - Enhanced comments and code documentation for maintainability.

- **Security and Logging:**
  - Reduced noise in security event logging by only logging failures and concerns.
  - Relaxed path validation for trusted file operations in the UI and command layer.

- **Dependency and Build Optimizations:**
  - Updated `Cargo.toml` and `Cargo.lock` with new optional dependencies and a release profile optimized for smaller, stripped binaries.
  - Ensured feature-gated compilation and modular import structure for UI components.

- **Bug Fixes and Consistency:**
  - Fixed field and annotation naming in JPA one-to-one and many-to-one relationship services for improved code generation consistency.
  - Updated deprecated function usage for package scope extraction to ensure compatibility.

## Technical Details

- The UI-enabled binary is built with `--features ui`, increasing binary size by ~4MB due to TUI dependencies.
- All interactive forms are implemented using `ratatui` and `crossterm`, with feature gating to keep the CLI-only binary minimal.
- The command layer is now the single source of truth for all business logic, with both CLI and TUI paths producing identical JSON responses.
- The release workflow now produces and uploads both CLI-only and UI-enabled binaries for Linux, macOS (Intel and Apple Silicon), and Windows, with clear separation and artifact naming.
- The architecture enforces stateless execution, clean separation of concerns, and UI-agnostic service logic, supporting both programmatic and interactive use cases.