### PR TITLE
Add multi-language support

### DIFF
--- a/src/commands/java/services/create_java_file_service.rs
+++ b/src/commands/java/services/create_java_file_service.rs
@@ -8,6 +8,7 @@ use crate::{
     },
   },
   common::{
+    supported_language::SupportedLanguage,
     ts_file::TSFile,
     utils::{case_util, path_security_util::PathSecurityValidator},
   },
@@ -22,7 +23,7 @@ pub fn generate_file_template(
 }
 
 pub fn create_ts_file(file_template: &str) -> TSFile {
-  TSFile::from_source_code(file_template)
+  TSFile::from_source_code(file_template, SupportedLanguage::Java)
 }
 
 pub fn correct_java_file_name(file_name: &str) -> String {

--- a/src/commands/java/services/create_jpa_entity_basic_field_service.rs
+++ b/src/commands/java/services/create_jpa_entity_basic_field_service.rs
@@ -13,6 +13,7 @@ use crate::commands::java::treesitter::types::java_basic_types::FieldInsertionPo
 use crate::commands::java::treesitter::types::java_field_temporal::JavaFieldTemporal;
 use crate::commands::java::treesitter::types::java_field_time_zone_storage::JavaFieldTimeZoneStorage;
 use crate::commands::java::treesitter::types::java_visibility_modifier::JavaVisibilityModifier;
+use crate::common::supported_language::SupportedLanguage;
 use crate::common::ts_file::TSFile;
 use crate::common::utils::case_util::{self, CaseType};
 use std::collections::{HashMap, HashSet};
@@ -201,7 +202,8 @@ pub fn run(
   // Step 1: Process field config
   let processed_field_config = process_field_config(field_config);
   // Step 2: Parse entity file
-  let mut entity_ts_file = TSFile::from_base64_source_code(entity_file_b64_src);
+  let mut entity_ts_file =
+    TSFile::from_base64_source_code(entity_file_b64_src, SupportedLanguage::Java);
   // Step 3: Process imports
   let mut import_map: HashMap<String, String> = HashMap::new();
   process_imports(&mut import_map, &processed_field_config, field_config);

--- a/src/commands/java/services/create_jpa_entity_enum_field_service.rs
+++ b/src/commands/java/services/create_jpa_entity_enum_field_service.rs
@@ -12,6 +12,7 @@ use crate::commands::java::treesitter::types::import_types::ImportInsertionPosit
 use crate::commands::java::treesitter::types::java_basic_types::FieldInsertionPosition;
 use crate::commands::java::treesitter::types::java_enum_type::JavaEnumType;
 use crate::commands::java::treesitter::types::java_visibility_modifier::JavaVisibilityModifier;
+use crate::common::supported_language::SupportedLanguage;
 use crate::common::ts_file::TSFile;
 use crate::common::utils::case_util::{self, CaseType};
 use std::collections::HashMap;
@@ -115,7 +116,8 @@ pub fn run(
   field_config: EnumFieldConfig,
 ) -> Result<FileResponse, String> {
   // Step 1: Parse the entity file
-  let mut entity_ts_file = TSFile::from_base64_source_code(entity_file_b64_src);
+  let mut entity_ts_file =
+    TSFile::from_base64_source_code(entity_file_b64_src, SupportedLanguage::Java);
   // Step 2: Prepare import map for required imports
   let mut import_map = HashMap::new();
   // Step 3: Add field and annotations to the entity

--- a/src/commands/java/services/create_jpa_entity_id_field_service.rs
+++ b/src/commands/java/services/create_jpa_entity_id_field_service.rs
@@ -13,6 +13,7 @@ use crate::commands::java::treesitter::types::java_basic_types::FieldInsertionPo
 use crate::commands::java::treesitter::types::java_id_generation::JavaIdGeneration;
 use crate::commands::java::treesitter::types::java_id_generation_type::JavaIdGenerationType;
 use crate::commands::java::treesitter::types::java_visibility_modifier::JavaVisibilityModifier;
+use crate::common::supported_language::SupportedLanguage;
 use crate::common::ts_file::TSFile;
 use crate::common::utils::case_util::{self, CaseType};
 use std::collections::HashMap;
@@ -169,7 +170,8 @@ pub fn run(
   field_config: IdFieldConfig,
 ) -> Result<FileResponse, String> {
   // Step 1: Parse the entity file
-  let mut entity_ts_file = TSFile::from_base64_source_code(entity_file_b64_src);
+  let mut entity_ts_file =
+    TSFile::from_base64_source_code(entity_file_b64_src, SupportedLanguage::Java);
   // Step 2: Prepare import map for required imports
   let mut import_map = HashMap::new();
   // Step 3: Add field and annotations to the entity

--- a/src/commands/java/services/create_jpa_many_to_one_relationship_service.rs
+++ b/src/commands/java/services/create_jpa_many_to_one_relationship_service.rs
@@ -18,6 +18,7 @@ use crate::commands::java::treesitter::types::java_visibility_modifier::JavaVisi
 use crate::commands::java::treesitter::types::many_to_one_field_config::ManyToOneFieldConfig;
 use crate::commands::java::treesitter::types::mapping_type::MappingType;
 use crate::commands::java::treesitter::types::other_type::OtherType;
+use crate::common::supported_language::SupportedLanguage;
 use crate::common::ts_file::TSFile;
 use crate::common::utils::case_util::{self, CaseType};
 use crate::common::utils::path_util::parse_all_files;
@@ -60,7 +61,7 @@ fn find_inverse_entity(cwd: &Path, class_name: &str) -> Result<PathBuf, String> 
 }
 
 fn extract_owning_entity_class_name(file_path: &Path) -> Result<String, String> {
-  let ts_file = TSFile::from_file(file_path)
+  let ts_file = TSFile::from_file(file_path, SupportedLanguage::Java)
     .map_err(|_| "Unable to parse owning side entity file".to_string())?;
   ts_file
     .get_file_name_without_ext()
@@ -68,8 +69,8 @@ fn extract_owning_entity_class_name(file_path: &Path) -> Result<String, String> 
 }
 
 fn get_entity_package_name(entity_file_path: &Path) -> Result<String, String> {
-  let entity_ts_file =
-    TSFile::from_file(entity_file_path).map_err(|_| "Unable to parse entity file".to_string())?;
+  let entity_ts_file = TSFile::from_file(entity_file_path, SupportedLanguage::Java)
+    .map_err(|_| "Unable to parse entity file".to_string())?;
   let package_node = get_package_declaration_node(&entity_ts_file)
     .ok_or_else(|| "Unable to get entity's package node".to_string())?;
   let package_scope_node = get_package_scope_node(&entity_ts_file, package_node);
@@ -84,9 +85,10 @@ fn parse_entity_file(
   entity_file_path: Option<&Path>,
 ) -> Result<TSFile, String> {
   if let Some(b64_src) = entity_file_b64_src {
-    Ok(TSFile::from_base64_source_code(b64_src))
+    Ok(TSFile::from_base64_source_code(b64_src, SupportedLanguage::Java))
   } else if let Some(f_path) = entity_file_path {
-    TSFile::from_file(f_path).map_err(|_| "Unable to parse Entity file".to_string())
+    TSFile::from_file(f_path, SupportedLanguage::Java)
+      .map_err(|_| "Unable to parse Entity file".to_string())
   } else {
     Err("Unable to parse Entity file".to_string())
   }

--- a/src/commands/java/services/create_jpa_one_to_one_relationship_service.rs
+++ b/src/commands/java/services/create_jpa_one_to_one_relationship_service.rs
@@ -17,6 +17,7 @@ use crate::commands::java::treesitter::types::java_visibility_modifier::JavaVisi
 use crate::commands::java::treesitter::types::mapping_type::MappingType;
 use crate::commands::java::treesitter::types::one_to_one_field_config::OneToOneFieldConfig;
 use crate::commands::java::treesitter::types::other_type::OtherType;
+use crate::common::supported_language::SupportedLanguage;
 use crate::common::ts_file::TSFile;
 use crate::common::utils::case_util::{self, CaseType};
 use crate::common::utils::path_util::parse_all_files;
@@ -80,7 +81,7 @@ fn extract_owning_entity_class_name(file_path: &Path) -> Result<String, String> 
 }
 
 fn get_entity_package_name(entity_file_path: &Path) -> Result<String, String> {
-  let ts_file = TSFile::from_file(entity_file_path)
+  let ts_file = TSFile::from_file(entity_file_path, SupportedLanguage::Java)
     .map_err(|_| "Unable to parse entity file for package name".to_string())?;
   let package_node = get_package_declaration_node(&ts_file)
     .ok_or_else(|| "Unable to get package declaration from entity".to_string())?;
@@ -96,9 +97,10 @@ fn parse_entity_file(
   entity_file_path: Option<&Path>,
 ) -> Result<TSFile, String> {
   if let Some(b64_src) = entity_file_b64_src {
-    Ok(TSFile::from_base64_source_code(b64_src))
+    Ok(TSFile::from_base64_source_code(b64_src, SupportedLanguage::Java))
   } else if let Some(f_path) = entity_file_path {
-    TSFile::from_file(f_path).map_err(|_| "Unable to parse Entity file".to_string())
+    TSFile::from_file(f_path, SupportedLanguage::Java)
+      .map_err(|_| "Unable to parse Entity file".to_string())
   } else {
     Err("Unable to parse Entity file".to_string())
   }

--- a/src/commands/java/services/create_jpa_repository_service.rs
+++ b/src/commands/java/services/create_jpa_repository_service.rs
@@ -15,6 +15,7 @@ use crate::commands::java::treesitter::services::package_declaration_service::{
 use crate::commands::java::treesitter::types::import_types::ImportInsertionPosition;
 use crate::commands::java::treesitter::types::java_file_type::JavaFileType;
 use crate::commands::java::treesitter::types::java_source_directory_type::JavaSourceDirectoryType;
+use crate::common::supported_language::SupportedLanguage;
 use crate::common::ts_file::TSFile;
 
 fn create_repository_file(
@@ -90,8 +91,9 @@ fn create_and_extend_jpa_repository(
   let create_repository_file_response =
     create_repository_file(cwd, entity_ts_file, entity_file_path)?;
   let jpa_repository_path = PathBuf::from(&create_repository_file_response.file_path);
-  let mut jpa_repository_ts_file = TSFile::from_file(jpa_repository_path.as_path())
-    .map_err(|e| format!("Unable to parse newly created repository file: {}", e))?;
+  let mut jpa_repository_ts_file =
+    TSFile::from_file(jpa_repository_path.as_path(), SupportedLanguage::Java)
+      .map_err(|e| format!("Unable to parse newly created repository file: {}", e))?;
   extend_jpa_repository(
     &mut jpa_repository_ts_file,
     entity_type,
@@ -229,7 +231,8 @@ pub fn run_with_manual_id(
   id_field_package_name: &str,
 ) -> Result<FileResponse, String> {
   // Step 1: Parse JPA Entity file
-  let entity_ts_file = TSFile::from_base64_source_code(entity_file_b64_src);
+  let entity_ts_file =
+    TSFile::from_base64_source_code(entity_file_b64_src, SupportedLanguage::Java);
   // Step 2: Extract entity type from file path
   let entity_type = entity_file_path
     .file_stem()
@@ -240,8 +243,9 @@ pub fn run_with_manual_id(
     create_repository_file(cwd, &entity_ts_file, entity_file_path)?;
   let jpa_repository_path = PathBuf::from(&create_repository_file_response.file_path);
   // Step 4: Parse and extend repository file
-  let mut jpa_repository_ts_file = TSFile::from_file(jpa_repository_path.as_path())
-    .map_err(|e| format!("Unable to parse newly created repository file: {}", e))?;
+  let mut jpa_repository_ts_file =
+    TSFile::from_file(jpa_repository_path.as_path(), SupportedLanguage::Java)
+      .map_err(|e| format!("Unable to parse newly created repository file: {}", e))?;
   extend_jpa_repository(
     &mut jpa_repository_ts_file,
     entity_type,
@@ -260,7 +264,8 @@ pub fn run(
   b64_superclass_source: Option<&str>,
 ) -> Result<CreateJPARepositoryResponse, String> {
   // Step 1: Parse JPA Entity file
-  let entity_ts_file = TSFile::from_base64_source_code(entity_file_b64_src);
+  let entity_ts_file =
+    TSFile::from_base64_source_code(entity_file_b64_src, SupportedLanguage::Java);
   // Step 2: Extract entity type from file path
   let entity_type = entity_file_path
     .file_stem()

--- a/src/commands/java/services/get_jpa_entity_info_service.rs
+++ b/src/commands/java/services/get_jpa_entity_info_service.rs
@@ -18,6 +18,7 @@ use crate::commands::java::treesitter::services::package_declaration_service::{
 use crate::commands::java::treesitter::services::{
   annotation_service, class_declaration_service, field_declaration_service,
 };
+use crate::common::supported_language::SupportedLanguage;
 use crate::common::ts_file::TSFile;
 
 fn decode_base64_to_bytes(b64: &str) -> Result<Vec<u8>, String> {
@@ -215,11 +216,11 @@ fn create_ts_file(
   b64_source_code: Option<&str>,
 ) -> Result<TSFile, String> {
   if let Some(path) = entity_file_path {
-    Ok(TSFile::from_file(path).map_err(|e| e.to_string())?)
+    Ok(TSFile::from_file(path, SupportedLanguage::Java).map_err(|e| e.to_string())?)
   } else if let Some(b64) = b64_source_code {
     let bytes = decode_base64_to_bytes(b64)?;
     let source = bytes_to_string(&bytes)?;
-    Ok(TSFile::from_source_code(&source))
+    Ok(TSFile::from_source_code(&source, SupportedLanguage::Java))
   } else {
     Err("No source provided".to_string())
   }

--- a/src/commands/java/treesitter/services/package_declaration_service.rs
+++ b/src/commands/java/treesitter/services/package_declaration_service.rs
@@ -16,8 +16,9 @@ use tree_sitter::Node;
 /// ```
 /// use syntaxpresso_core::commands::java::treesitter::services::package_declaration_service::get_package_declaration_node;
 /// use syntaxpresso_core::common::ts_file::TSFile;
+/// use syntaxpresso_core::common::supported_language::SupportedLanguage;
 ///
-/// let ts_file = TSFile::from_source_code("package com.example.myapp;");
+/// let ts_file = TSFile::from_source_code("package com.example.myapp;", SupportedLanguage::Java);
 /// let package_node = get_package_declaration_node(&ts_file);
 /// // Returns the entire package_declaration node
 /// ```
@@ -43,8 +44,9 @@ pub fn get_package_declaration_node(ts_file: &TSFile) -> Option<Node<'_>> {
 /// ```
 /// use syntaxpresso_core::commands::java::treesitter::services::package_declaration_service::{get_package_class_name_node, get_package_declaration_node};
 /// use syntaxpresso_core::common::ts_file::TSFile;
+/// use syntaxpresso_core::common::supported_language::SupportedLanguage;
 ///
-/// let ts_file = TSFile::from_source_code("package com.example.myapp;");
+/// let ts_file = TSFile::from_source_code("package com.example.myapp;", SupportedLanguage::Java);
 /// let package_node = get_package_declaration_node(&ts_file).unwrap();
 /// let class_name_node = get_package_class_name_node(&ts_file, package_node);
 /// if let Some(node) = class_name_node {
@@ -90,8 +92,9 @@ pub fn get_package_class_name_node<'a>(
 /// ```
 /// use syntaxpresso_core::commands::java::treesitter::services::package_declaration_service::{get_package_class_scope_node, get_package_declaration_node};
 /// use syntaxpresso_core::common::ts_file::TSFile;
+/// use syntaxpresso_core::common::supported_language::SupportedLanguage;
 ///
-/// let ts_file = TSFile::from_source_code("package com.example.myapp;");
+/// let ts_file = TSFile::from_source_code("package com.example.myapp;", SupportedLanguage::Java);
 /// let package_node = get_package_declaration_node(&ts_file).unwrap();
 /// let scope_node = get_package_class_scope_node(&ts_file, package_node);
 /// if let Some(node) = scope_node {
@@ -137,8 +140,9 @@ pub fn get_package_class_scope_node<'a>(
 /// ```
 /// use syntaxpresso_core::commands::java::treesitter::services::package_declaration_service::{get_package_scope_node, get_package_declaration_node};
 /// use syntaxpresso_core::common::ts_file::TSFile;
+/// use syntaxpresso_core::common::supported_language::SupportedLanguage;
 ///
-/// let ts_file = TSFile::from_source_code("package com.example.myapp;");
+/// let ts_file = TSFile::from_source_code("package com.example.myapp;", SupportedLanguage::Java);
 /// let package_node = get_package_declaration_node(&ts_file).unwrap();
 /// let scope_node = get_package_scope_node(&ts_file, package_node);
 /// if let Some(node) = scope_node {

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -1,6 +1,7 @@
 pub mod error_response;
 pub mod query;
 pub mod response;
+pub mod supported_language;
 pub mod ts_file;
 pub mod utils;
 pub mod validators;

--- a/src/common/supported_language.rs
+++ b/src/common/supported_language.rs
@@ -1,0 +1,65 @@
+use tree_sitter::Language;
+
+/// Enum representing programming languages supported by Syntaxpresso
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SupportedLanguage {
+  /// Java programming language
+  Java,
+  // Future languages can be added here:
+  // Python,
+  // TypeScript,
+  // JavaScript,
+}
+
+impl SupportedLanguage {
+  /// Get the tree-sitter Language object for this language
+  ///
+  /// This provides the Tree-sitter grammar needed to parse source code
+  /// in the specified language.
+  ///
+  /// # Examples
+  ///
+  /// ```
+  /// use syntaxpresso_core::common::supported_language::SupportedLanguage;
+  ///
+  /// let language = SupportedLanguage::Java;
+  /// let ts_language = language.tree_sitter_language();
+  /// ```
+  pub fn tree_sitter_language(&self) -> Language {
+    match self {
+      SupportedLanguage::Java => tree_sitter_java::LANGUAGE.into(),
+    }
+  }
+
+  /// Get the primary file extension for this language
+  ///
+  /// Returns the most common file extension without the leading dot.
+  ///
+  /// # Examples
+  ///
+  /// ```
+  /// use syntaxpresso_core::common::supported_language::SupportedLanguage;
+  ///
+  /// assert_eq!(SupportedLanguage::Java.file_extension(), "java");
+  /// ```
+  pub fn file_extension(&self) -> &'static str {
+    match self {
+      SupportedLanguage::Java => "java",
+    }
+  }
+
+  /// Get the human-readable name of the language
+  ///
+  /// # Examples
+  ///
+  /// ```
+  /// use syntaxpresso_core::common::supported_language::SupportedLanguage;
+  ///
+  /// assert_eq!(SupportedLanguage::Java.name(), "Java");
+  /// ```
+  pub fn name(&self) -> &'static str {
+    match self {
+      SupportedLanguage::Java => "Java",
+    }
+  }
+}

--- a/src/common/utils/path_util.rs
+++ b/src/common/utils/path_util.rs
@@ -7,7 +7,10 @@ use walkdir::WalkDir;
 
 use crate::{
   commands::java::treesitter::types::java_source_directory_type::JavaSourceDirectoryType,
-  common::{ts_file::TSFile, utils::path_security_util::PathSecurityValidator},
+  common::{
+    supported_language::SupportedLanguage, ts_file::TSFile,
+    utils::path_security_util::PathSecurityValidator,
+  },
 };
 
 /// Recursively searches for a directory with the given name within the root directory.
@@ -38,7 +41,7 @@ pub fn parse_all_files(cwd: &Path, source_directory_type: &JavaSourceDirectoryTy
       let path = entry.path();
       if let Some(ext) = path.extension()
         && ext.to_string_lossy().eq_ignore_ascii_case(extension)
-        && let Ok(ts_file) = TSFile::from_file(path)
+        && let Ok(ts_file) = TSFile::from_file(path, SupportedLanguage::Java)
       {
         files.push(ts_file);
       }

--- a/tests/annotation_service_tests.rs
+++ b/tests/annotation_service_tests.rs
@@ -2,10 +2,11 @@
 mod annotation_service_tests {
   use syntaxpresso_core::commands::java::treesitter::services::annotation_service::*;
   use syntaxpresso_core::commands::java::treesitter::types::annotation_types::AnnotationInsertionPosition;
+  use syntaxpresso_core::common::supported_language::SupportedLanguage;
   use syntaxpresso_core::common::ts_file::TSFile;
 
   fn create_ts_file(content: &str) -> TSFile {
-    TSFile::from_source_code(content)
+    TSFile::from_source_code(content, SupportedLanguage::Java)
   }
 
   const SIMPLE_JAVA_CLASS: &str = "@Entity\npublic class User {\n    @Id\n    private Long id;\n}";
@@ -279,7 +280,7 @@ public class User {
 
   #[test]
   fn test_get_all_annotation_nodes_no_tree() {
-    let mut ts_file_no_tree = TSFile::from_source_code("");
+    let mut ts_file_no_tree = TSFile::from_source_code("", SupportedLanguage::Java);
     ts_file_no_tree.tree = None;
 
     let ts_file = create_ts_file("public class Test {}");

--- a/tests/class_declaration_service_tests.rs
+++ b/tests/class_declaration_service_tests.rs
@@ -1,11 +1,12 @@
 #[cfg(test)]
 mod class_declaration_service_tests {
   use syntaxpresso_core::commands::java::treesitter::services::class_declaration_service::*;
+  use syntaxpresso_core::common::supported_language::SupportedLanguage;
   use syntaxpresso_core::common::ts_file::TSFile;
 
   // Helper function to create TSFile from Java content
   fn create_ts_file_from_content(content: &str, _file_name: Option<&str>) -> TSFile {
-    TSFile::from_source_code(content)
+    TSFile::from_source_code(content, SupportedLanguage::Java)
   }
 
   #[test]

--- a/tests/field_declaration_service_tests.rs
+++ b/tests/field_declaration_service_tests.rs
@@ -2,10 +2,11 @@
 mod field_declaration_service_tests {
   use syntaxpresso_core::commands::java::treesitter::services::class_declaration_service::find_class_node_by_name;
   use syntaxpresso_core::commands::java::treesitter::services::field_declaration_service::*;
+  use syntaxpresso_core::common::supported_language::SupportedLanguage;
   use syntaxpresso_core::common::ts_file::TSFile;
 
   fn create_ts_file(content: &str) -> TSFile {
-    TSFile::from_source_code(content)
+    TSFile::from_source_code(content, SupportedLanguage::Java)
   }
 
   const SIMPLE_JAVA_CLASS: &str = r#"

--- a/tests/import_declaration_service_tests.rs
+++ b/tests/import_declaration_service_tests.rs
@@ -3,6 +3,7 @@
 
 use syntaxpresso_core::commands::java::treesitter::services::import_declaration_service::*;
 use syntaxpresso_core::commands::java::treesitter::types::import_types::ImportInsertionPosition;
+use syntaxpresso_core::common::supported_language::SupportedLanguage;
 use syntaxpresso_core::common::ts_file::TSFile;
 
 #[cfg(test)]
@@ -22,7 +23,7 @@ import java.util.List;
 
 public class Test {}
       "#;
-      let ts_file = TSFile::from_source_code(java_code);
+      let ts_file = TSFile::from_source_code(java_code, SupportedLanguage::Java);
       let imports = get_all_import_declaration_nodes(&ts_file);
 
       assert_eq!(imports.len(), 1, "Should find exactly one import declaration");
@@ -41,7 +42,7 @@ import com.example.service.MyService;
 
 public class Test {}
       "#;
-      let ts_file = TSFile::from_source_code(java_code);
+      let ts_file = TSFile::from_source_code(java_code, SupportedLanguage::Java);
       let imports = get_all_import_declaration_nodes(&ts_file);
 
       assert_eq!(imports.len(), 4, "Should find exactly four import declarations");
@@ -61,7 +62,7 @@ package com.example;
 
 public class Test {}
       "#;
-      let ts_file = TSFile::from_source_code(java_code);
+      let ts_file = TSFile::from_source_code(java_code, SupportedLanguage::Java);
       let imports = get_all_import_declaration_nodes(&ts_file);
 
       assert!(imports.is_empty(), "Should return empty vector when no imports exist");
@@ -76,7 +77,7 @@ import java.util.*;
 
 public class Test {}
       "#;
-      let ts_file = TSFile::from_source_code(java_code);
+      let ts_file = TSFile::from_source_code(java_code, SupportedLanguage::Java);
       let imports = get_all_import_declaration_nodes(&ts_file);
 
       assert_eq!(imports.len(), 1, "Should find wildcard import declaration");
@@ -93,7 +94,7 @@ import static java.util.Collections.*;
 
 public class Test {}
       "#;
-      let ts_file = TSFile::from_source_code(java_code);
+      let ts_file = TSFile::from_source_code(java_code, SupportedLanguage::Java);
       let imports = get_all_import_declaration_nodes(&ts_file);
 
       assert_eq!(imports.len(), 2, "Should find both static import declarations");
@@ -108,7 +109,7 @@ public class Test {}
 
     #[test]
     fn test_empty_file() {
-      let ts_file = TSFile::from_source_code("");
+      let ts_file = TSFile::from_source_code("", SupportedLanguage::Java);
       let imports = get_all_import_declaration_nodes(&ts_file);
 
       assert!(imports.is_empty(), "Should return empty vector for empty file");
@@ -116,7 +117,7 @@ public class Test {}
 
     #[test]
     fn test_invalid_syntax() {
-      let ts_file = TSFile::from_source_code("invalid java syntax here");
+      let ts_file = TSFile::from_source_code("invalid java syntax here", SupportedLanguage::Java);
       let imports = get_all_import_declaration_nodes(&ts_file);
 
       assert!(imports.is_empty(), "Should return empty vector for invalid syntax");
@@ -130,7 +131,7 @@ public class Test {}
     #[test]
     fn test_multi_component_import_scope() {
       let java_code = "import com.example.service.MyService;";
-      let ts_file = TSFile::from_source_code(java_code);
+      let ts_file = TSFile::from_source_code(java_code, SupportedLanguage::Java);
       let imports = get_all_import_declaration_nodes(&ts_file);
       assert!(!imports.is_empty(), "Should have at least one import");
 
@@ -146,7 +147,7 @@ public class Test {}
     #[test]
     fn test_deep_nested_import_scope() {
       let java_code = "import com.company.project.module.submodule.feature.MyClass;";
-      let ts_file = TSFile::from_source_code(java_code);
+      let ts_file = TSFile::from_source_code(java_code, SupportedLanguage::Java);
       let imports = get_all_import_declaration_nodes(&ts_file);
       assert!(!imports.is_empty(), "Should have at least one import");
 
@@ -163,7 +164,7 @@ public class Test {}
     #[test]
     fn test_single_component_import() {
       let java_code = "import MyClass;";
-      let ts_file = TSFile::from_source_code(java_code);
+      let ts_file = TSFile::from_source_code(java_code, SupportedLanguage::Java);
       let imports = get_all_import_declaration_nodes(&ts_file);
 
       if !imports.is_empty() {
@@ -177,7 +178,7 @@ public class Test {}
     #[test]
     fn test_wildcard_import_scope() {
       let java_code = "import java.util.*;";
-      let ts_file = TSFile::from_source_code(java_code);
+      let ts_file = TSFile::from_source_code(java_code, SupportedLanguage::Java);
       let imports = get_all_import_declaration_nodes(&ts_file);
       assert!(!imports.is_empty(), "Should have wildcard import");
 
@@ -193,7 +194,7 @@ public class Test {}
     #[test]
     fn test_invalid_node_type() {
       let java_code = "package com.example;";
-      let ts_file = TSFile::from_source_code(java_code);
+      let ts_file = TSFile::from_source_code(java_code, SupportedLanguage::Java);
       let root = ts_file.tree.as_ref().unwrap().root_node();
 
       let result = get_import_declaration_relative_import_scope_node(&ts_file, root);
@@ -208,7 +209,7 @@ public class Test {}
     #[test]
     fn test_multi_component_import_class_name() {
       let java_code = "import com.example.service.MyService;";
-      let ts_file = TSFile::from_source_code(java_code);
+      let ts_file = TSFile::from_source_code(java_code, SupportedLanguage::Java);
       let imports = get_all_import_declaration_nodes(&ts_file);
       assert!(!imports.is_empty(), "Should have at least one import");
 
@@ -222,7 +223,7 @@ public class Test {}
     #[test]
     fn test_deep_nested_import_class_name() {
       let java_code = "import com.company.project.module.submodule.feature.MyClass;";
-      let ts_file = TSFile::from_source_code(java_code);
+      let ts_file = TSFile::from_source_code(java_code, SupportedLanguage::Java);
       let imports = get_all_import_declaration_nodes(&ts_file);
       assert!(!imports.is_empty(), "Should have at least one import");
 
@@ -236,7 +237,7 @@ public class Test {}
     #[test]
     fn test_two_component_import_class_name() {
       let java_code = "import java.List;";
-      let ts_file = TSFile::from_source_code(java_code);
+      let ts_file = TSFile::from_source_code(java_code, SupportedLanguage::Java);
       let imports = get_all_import_declaration_nodes(&ts_file);
 
       if !imports.is_empty() {
@@ -251,7 +252,7 @@ public class Test {}
     #[test]
     fn test_single_component_import_class_name() {
       let java_code = "import MyClass;";
-      let ts_file = TSFile::from_source_code(java_code);
+      let ts_file = TSFile::from_source_code(java_code, SupportedLanguage::Java);
       let imports = get_all_import_declaration_nodes(&ts_file);
 
       if !imports.is_empty() {
@@ -264,7 +265,7 @@ public class Test {}
     #[test]
     fn test_wildcard_import_class_name() {
       let java_code = "import java.util.*;";
-      let ts_file = TSFile::from_source_code(java_code);
+      let ts_file = TSFile::from_source_code(java_code, SupportedLanguage::Java);
       let imports = get_all_import_declaration_nodes(&ts_file);
       assert!(!imports.is_empty(), "Should have wildcard import");
 
@@ -280,7 +281,7 @@ public class Test {}
     #[test]
     fn test_invalid_node_type() {
       let java_code = "package com.example;";
-      let ts_file = TSFile::from_source_code(java_code);
+      let ts_file = TSFile::from_source_code(java_code, SupportedLanguage::Java);
       let root = ts_file.tree.as_ref().unwrap().root_node();
 
       let result = get_import_declaration_class_name_node(&ts_file, root);
@@ -295,7 +296,7 @@ public class Test {}
     #[test]
     fn test_complete_multi_component_import() {
       let java_code = "import com.example.service.MyService;";
-      let ts_file = TSFile::from_source_code(java_code);
+      let ts_file = TSFile::from_source_code(java_code, SupportedLanguage::Java);
       let imports = get_all_import_declaration_nodes(&ts_file);
       assert!(!imports.is_empty(), "Should have at least one import");
 
@@ -312,7 +313,7 @@ public class Test {}
     #[test]
     fn test_complete_deep_nested_import() {
       let java_code = "import com.company.project.module.submodule.feature.MyClass;";
-      let ts_file = TSFile::from_source_code(java_code);
+      let ts_file = TSFile::from_source_code(java_code, SupportedLanguage::Java);
       let imports = get_all_import_declaration_nodes(&ts_file);
       assert!(!imports.is_empty(), "Should have at least one import");
 
@@ -329,7 +330,7 @@ public class Test {}
     #[test]
     fn test_wildcard_import_full_scope() {
       let java_code = "import java.util.*;";
-      let ts_file = TSFile::from_source_code(java_code);
+      let ts_file = TSFile::from_source_code(java_code, SupportedLanguage::Java);
       let imports = get_all_import_declaration_nodes(&ts_file);
       assert!(!imports.is_empty(), "Should have wildcard import");
 
@@ -343,7 +344,7 @@ public class Test {}
     #[test]
     fn test_single_component_import_full_scope() {
       let java_code = "import MyClass;";
-      let ts_file = TSFile::from_source_code(java_code);
+      let ts_file = TSFile::from_source_code(java_code, SupportedLanguage::Java);
       let imports = get_all_import_declaration_nodes(&ts_file);
 
       if !imports.is_empty() {
@@ -359,7 +360,7 @@ public class Test {}
     #[test]
     fn test_invalid_node_type() {
       let java_code = "package com.example;";
-      let ts_file = TSFile::from_source_code(java_code);
+      let ts_file = TSFile::from_source_code(java_code, SupportedLanguage::Java);
       let root = ts_file.tree.as_ref().unwrap().root_node();
 
       let result = get_import_declaration_full_import_scope_node(&ts_file, root);
@@ -382,7 +383,7 @@ import java.io.File;
 
 public class Test {}
       "#;
-      let ts_file = TSFile::from_source_code(java_code);
+      let ts_file = TSFile::from_source_code(java_code, SupportedLanguage::Java);
 
       let result = find_import_declaration_node(&ts_file, "com.example.service", "MyService");
       assert!(result.is_some(), "Should find existing import declaration");
@@ -405,7 +406,7 @@ import com.example.service.MyService;
 
 public class Test {}
       "#;
-      let ts_file = TSFile::from_source_code(java_code);
+      let ts_file = TSFile::from_source_code(java_code, SupportedLanguage::Java);
 
       // For wildcard imports, the class_name parameter represents the wildcard package
       let result = find_import_declaration_node(&ts_file, "java.util", "*");
@@ -428,7 +429,7 @@ import com.example.service.MyService;
 
 public class Test {}
       "#;
-      let ts_file = TSFile::from_source_code(java_code);
+      let ts_file = TSFile::from_source_code(java_code, SupportedLanguage::Java);
 
       let result = find_import_declaration_node(&ts_file, "com.nonexistent", "NonExistent");
       assert!(result.is_none(), "Should return None for non-existent import");
@@ -439,7 +440,7 @@ public class Test {}
       let java_code = r#"
 import java.util.List;
       "#;
-      let ts_file = TSFile::from_source_code(java_code);
+      let ts_file = TSFile::from_source_code(java_code, SupportedLanguage::Java);
 
       let result1 = find_import_declaration_node(&ts_file, "", "List");
       assert!(result1.is_none(), "Should return None for empty package scope");
@@ -455,7 +456,7 @@ package com.example;
 
 public class Test {}
       "#;
-      let ts_file = TSFile::from_source_code(java_code);
+      let ts_file = TSFile::from_source_code(java_code, SupportedLanguage::Java);
 
       let result = find_import_declaration_node(&ts_file, "java.util", "List");
       assert!(result.is_none(), "Should return None when no imports exist");
@@ -464,7 +465,7 @@ public class Test {}
     #[test]
     fn test_find_with_case_sensitivity() {
       let java_code = "import com.example.service.MyService;";
-      let ts_file = TSFile::from_source_code(java_code);
+      let ts_file = TSFile::from_source_code(java_code, SupportedLanguage::Java);
 
       let result1 = find_import_declaration_node(&ts_file, "com.example.service", "MyService");
       assert!(result1.is_some(), "Should find exact case match");
@@ -483,7 +484,7 @@ public class Test {}
       let java_code = r#"package com.example;
 
 public class Test {}"#;
-      let mut ts_file = TSFile::from_source_code(java_code);
+      let mut ts_file = TSFile::from_source_code(java_code, SupportedLanguage::Java);
 
       let result = add_import(
         &mut ts_file,
@@ -509,7 +510,7 @@ public class Test {}"#;
 import java.io.File;
 
 public class Test {}"#;
-      let mut ts_file = TSFile::from_source_code(java_code);
+      let mut ts_file = TSFile::from_source_code(java_code, SupportedLanguage::Java);
 
       let result =
         add_import(&mut ts_file, &ImportInsertionPosition::BeforeFirstImport, "java.util", "List");
@@ -527,7 +528,7 @@ import java.util.List;
 import java.io.File;
 
 public class Test {}"#;
-      let mut ts_file = TSFile::from_source_code(java_code);
+      let mut ts_file = TSFile::from_source_code(java_code, SupportedLanguage::Java);
 
       let result =
         add_import(&mut ts_file, &ImportInsertionPosition::AfterLastImport, "java.util", "Map");
@@ -544,7 +545,7 @@ public class Test {}"#;
 import java.util.List;
 
 public class Test {}"#;
-      let mut ts_file = TSFile::from_source_code(java_code);
+      let mut ts_file = TSFile::from_source_code(java_code, SupportedLanguage::Java);
 
       let result =
         add_import(&mut ts_file, &ImportInsertionPosition::AfterLastImport, "java.util", "List");
@@ -556,7 +557,7 @@ public class Test {}"#;
 
     #[test]
     fn test_add_import_to_empty_file() {
-      let mut ts_file = TSFile::from_source_code("");
+      let mut ts_file = TSFile::from_source_code("", SupportedLanguage::Java);
 
       let result = add_import(
         &mut ts_file,
@@ -573,7 +574,7 @@ public class Test {}"#;
 
     #[test]
     fn test_add_import_with_empty_parameters() {
-      let mut ts_file = TSFile::from_source_code("package com.example;");
+      let mut ts_file = TSFile::from_source_code("package com.example;", SupportedLanguage::Java);
 
       let result1 =
         add_import(&mut ts_file, &ImportInsertionPosition::AfterPackageDeclaration, "", "List");
@@ -597,7 +598,7 @@ public class Test {}"#;
       let java_code = r#"import java.io.File;
 
 public class Test {}"#;
-      let mut ts_file = TSFile::from_source_code(java_code);
+      let mut ts_file = TSFile::from_source_code(java_code, SupportedLanguage::Java);
 
       let result =
         add_import(&mut ts_file, &ImportInsertionPosition::BeforeFirstImport, "java.util", "List");
@@ -617,7 +618,7 @@ public class Test {}"#;
 import java.util.List;
 
 public class Test {}"#;
-      let mut ts_file = TSFile::from_source_code(java_code);
+      let mut ts_file = TSFile::from_source_code(java_code, SupportedLanguage::Java);
 
       let result =
         add_import(&mut ts_file, &ImportInsertionPosition::AfterLastImport, "java.io", "File");
@@ -651,7 +652,7 @@ import java.io.File;
 import com.example.service.MyService;
 
 public class MyClass {}"#;
-      let mut ts_file = TSFile::from_source_code(java_code);
+      let mut ts_file = TSFile::from_source_code(java_code, SupportedLanguage::Java);
 
       // Test finding existing imports
       let existing_import = find_import_declaration_node(&ts_file, "java.util", "List");
@@ -716,7 +717,7 @@ import com.example.repository.UserRepository;
 public class UserServiceImpl implements UserService {
     // Implementation details
 }"#;
-      let mut ts_file = TSFile::from_source_code(java_code);
+      let mut ts_file = TSFile::from_source_code(java_code, SupportedLanguage::Java);
 
       // Test finding various types of imports
       let _wildcard_import = find_import_declaration_node(&ts_file, "java.util", "*");
@@ -754,7 +755,7 @@ public class UserServiceImpl implements UserService {
       ];
 
       for (code, description) in test_cases {
-        let mut ts_file = TSFile::from_source_code(code);
+        let mut ts_file = TSFile::from_source_code(code, SupportedLanguage::Java);
 
         // Test that all functions handle edge cases gracefully
         let all_imports = get_all_import_declaration_nodes(&ts_file);

--- a/tests/interface_declaration_service_tests.rs
+++ b/tests/interface_declaration_service_tests.rs
@@ -1,10 +1,11 @@
 #[cfg(test)]
 mod interface_declaration_service_tests {
   use syntaxpresso_core::commands::java::treesitter::services::interface_declaration_service::*;
+  use syntaxpresso_core::common::supported_language::SupportedLanguage;
   use syntaxpresso_core::common::ts_file::TSFile;
 
   fn create_ts_file(content: &str) -> TSFile {
-    TSFile::from_source_code(content)
+    TSFile::from_source_code(content, SupportedLanguage::Java)
   }
 
   const SIMPLE_INTERFACE: &str = r#"

--- a/tests/package_declaration_service_tests.rs
+++ b/tests/package_declaration_service_tests.rs
@@ -2,6 +2,7 @@
 // This module contains comprehensive tests for all package declaration service functions
 
 use syntaxpresso_core::commands::java::treesitter::services::package_declaration_service::*;
+use syntaxpresso_core::common::supported_language::SupportedLanguage;
 use syntaxpresso_core::common::ts_file::TSFile;
 
 #[cfg(test)]
@@ -14,7 +15,10 @@ mod package_declaration_tests {
 
     #[test]
     fn test_valid_multi_component_package() {
-      let ts_file = TSFile::from_source_code("package com.example.myapp;\n\npublic class Test {}");
+      let ts_file = TSFile::from_source_code(
+        "package com.example.myapp;\n\npublic class Test {}",
+        SupportedLanguage::Java,
+      );
       let result = get_package_declaration_node(&ts_file);
 
       assert!(result.is_some(), "Should find package declaration node");
@@ -28,7 +32,8 @@ mod package_declaration_tests {
 
     #[test]
     fn test_valid_single_component_package() {
-      let ts_file = TSFile::from_source_code("package myapp;\n\npublic class Test {}");
+      let ts_file =
+        TSFile::from_source_code("package myapp;\n\npublic class Test {}", SupportedLanguage::Java);
       let result = get_package_declaration_node(&ts_file);
 
       assert!(result.is_some(), "Should find single component package declaration");
@@ -39,7 +44,7 @@ mod package_declaration_tests {
 
     #[test]
     fn test_no_package_declaration() {
-      let ts_file = TSFile::from_source_code("public class Test {}");
+      let ts_file = TSFile::from_source_code("public class Test {}", SupportedLanguage::Java);
       let result = get_package_declaration_node(&ts_file);
 
       assert!(result.is_none(), "Should return None when no package declaration exists");
@@ -47,7 +52,7 @@ mod package_declaration_tests {
 
     #[test]
     fn test_empty_file() {
-      let ts_file = TSFile::from_source_code("");
+      let ts_file = TSFile::from_source_code("", SupportedLanguage::Java);
       let result = get_package_declaration_node(&ts_file);
 
       assert!(result.is_none(), "Should return None for empty file");
@@ -55,8 +60,10 @@ mod package_declaration_tests {
 
     #[test]
     fn test_package_with_whitespace() {
-      let ts_file =
-        TSFile::from_source_code("   package    com.example.myapp   ;\n\npublic class Test {}");
+      let ts_file = TSFile::from_source_code(
+        "   package    com.example.myapp   ;\n\npublic class Test {}",
+        SupportedLanguage::Java,
+      );
       let result = get_package_declaration_node(&ts_file);
 
       assert!(result.is_some(), "Should handle whitespace around package declaration");
@@ -75,6 +82,7 @@ mod package_declaration_tests {
                 // Some comment
                 public class Test {}
             "#,
+        SupportedLanguage::Java,
       );
 
       let result = get_package_declaration_node(&ts_file);
@@ -83,8 +91,10 @@ mod package_declaration_tests {
 
     #[test]
     fn test_deep_nested_package() {
-      let ts_file =
-        TSFile::from_source_code("package com.company.project.module.submodule.feature;");
+      let ts_file = TSFile::from_source_code(
+        "package com.company.project.module.submodule.feature;",
+        SupportedLanguage::Java,
+      );
       let result = get_package_declaration_node(&ts_file);
 
       assert!(result.is_some(), "Should handle deeply nested package declarations");
@@ -98,7 +108,7 @@ mod package_declaration_tests {
 
     #[test]
     fn test_invalid_java_syntax() {
-      let ts_file = TSFile::from_source_code("invalid java syntax here");
+      let ts_file = TSFile::from_source_code("invalid java syntax here", SupportedLanguage::Java);
       let result = get_package_declaration_node(&ts_file);
 
       assert!(result.is_none(), "Should return None for invalid Java syntax");
@@ -111,7 +121,7 @@ mod package_declaration_tests {
 
     #[test]
     fn test_multi_component_package_class_name() {
-      let ts_file = TSFile::from_source_code("package com.example.myapp;");
+      let ts_file = TSFile::from_source_code("package com.example.myapp;", SupportedLanguage::Java);
       let package_node = get_package_declaration_node(&ts_file).unwrap();
       let result = get_package_class_name_node(&ts_file, package_node);
 
@@ -123,8 +133,10 @@ mod package_declaration_tests {
 
     #[test]
     fn test_deep_nested_package_class_name() {
-      let ts_file =
-        TSFile::from_source_code("package com.company.project.module.submodule.feature;");
+      let ts_file = TSFile::from_source_code(
+        "package com.company.project.module.submodule.feature;",
+        SupportedLanguage::Java,
+      );
       let package_node = get_package_declaration_node(&ts_file).unwrap();
       let result = get_package_class_name_node(&ts_file, package_node);
 
@@ -136,7 +148,7 @@ mod package_declaration_tests {
 
     #[test]
     fn test_single_component_package_class_name() {
-      let ts_file = TSFile::from_source_code("package myapp;");
+      let ts_file = TSFile::from_source_code("package myapp;", SupportedLanguage::Java);
       let package_node = get_package_declaration_node(&ts_file).unwrap();
       let result = get_package_class_name_node(&ts_file, package_node);
 
@@ -147,7 +159,7 @@ mod package_declaration_tests {
 
     #[test]
     fn test_two_component_package_class_name() {
-      let ts_file = TSFile::from_source_code("package com.myapp;");
+      let ts_file = TSFile::from_source_code("package com.myapp;", SupportedLanguage::Java);
       let package_node = get_package_declaration_node(&ts_file).unwrap();
       let result = get_package_class_name_node(&ts_file, package_node);
 
@@ -159,7 +171,8 @@ mod package_declaration_tests {
 
     #[test]
     fn test_class_name_with_whitespace() {
-      let ts_file = TSFile::from_source_code("package   com.example.myapp   ;");
+      let ts_file =
+        TSFile::from_source_code("package   com.example.myapp   ;", SupportedLanguage::Java);
       let package_node = get_package_declaration_node(&ts_file).unwrap();
       let result = get_package_class_name_node(&ts_file, package_node);
 
@@ -176,7 +189,7 @@ mod package_declaration_tests {
 
     #[test]
     fn test_multi_component_package_scope() {
-      let ts_file = TSFile::from_source_code("package com.example.myapp;");
+      let ts_file = TSFile::from_source_code("package com.example.myapp;", SupportedLanguage::Java);
       let package_node = get_package_declaration_node(&ts_file).unwrap();
       let result = get_package_class_scope_node(&ts_file, package_node);
 
@@ -188,8 +201,10 @@ mod package_declaration_tests {
 
     #[test]
     fn test_deep_nested_package_scope() {
-      let ts_file =
-        TSFile::from_source_code("package com.company.project.module.submodule.feature;");
+      let ts_file = TSFile::from_source_code(
+        "package com.company.project.module.submodule.feature;",
+        SupportedLanguage::Java,
+      );
       let package_node = get_package_declaration_node(&ts_file).unwrap();
       let result = get_package_class_scope_node(&ts_file, package_node);
 
@@ -204,7 +219,7 @@ mod package_declaration_tests {
 
     #[test]
     fn test_two_component_package_scope() {
-      let ts_file = TSFile::from_source_code("package com.myapp;");
+      let ts_file = TSFile::from_source_code("package com.myapp;", SupportedLanguage::Java);
       let package_node = get_package_declaration_node(&ts_file).unwrap();
       let result = get_package_class_scope_node(&ts_file, package_node);
 
@@ -216,7 +231,7 @@ mod package_declaration_tests {
 
     #[test]
     fn test_single_component_package_scope() {
-      let ts_file = TSFile::from_source_code("package myapp;");
+      let ts_file = TSFile::from_source_code("package myapp;", SupportedLanguage::Java);
       let package_node = get_package_declaration_node(&ts_file).unwrap();
       let result = get_package_class_scope_node(&ts_file, package_node);
 
@@ -226,7 +241,8 @@ mod package_declaration_tests {
 
     #[test]
     fn test_scope_with_whitespace() {
-      let ts_file = TSFile::from_source_code("package   com.example.myapp   ;");
+      let ts_file =
+        TSFile::from_source_code("package   com.example.myapp   ;", SupportedLanguage::Java);
       let package_node = get_package_declaration_node(&ts_file).unwrap();
       let result = get_package_class_scope_node(&ts_file, package_node);
 
@@ -243,7 +259,7 @@ mod package_declaration_tests {
 
     #[test]
     fn test_complete_multi_component_identifier() {
-      let ts_file = TSFile::from_source_code("package com.example.myapp;");
+      let ts_file = TSFile::from_source_code("package com.example.myapp;", SupportedLanguage::Java);
       let package_node = get_package_declaration_node(&ts_file).unwrap();
       let result = get_package_scope_node(&ts_file, package_node);
 
@@ -255,8 +271,10 @@ mod package_declaration_tests {
 
     #[test]
     fn test_complete_deep_nested_identifier() {
-      let ts_file =
-        TSFile::from_source_code("package com.company.project.module.submodule.feature;");
+      let ts_file = TSFile::from_source_code(
+        "package com.company.project.module.submodule.feature;",
+        SupportedLanguage::Java,
+      );
       let package_node = get_package_declaration_node(&ts_file).unwrap();
       let result = get_package_scope_node(&ts_file, package_node);
 
@@ -271,7 +289,7 @@ mod package_declaration_tests {
 
     #[test]
     fn test_complete_two_component_identifier() {
-      let ts_file = TSFile::from_source_code("package com.myapp;");
+      let ts_file = TSFile::from_source_code("package com.myapp;", SupportedLanguage::Java);
       let package_node = get_package_declaration_node(&ts_file).unwrap();
       let result = get_package_scope_node(&ts_file, package_node);
 
@@ -283,7 +301,7 @@ mod package_declaration_tests {
 
     #[test]
     fn test_single_component_identifier() {
-      let ts_file = TSFile::from_source_code("package myapp;");
+      let ts_file = TSFile::from_source_code("package myapp;", SupportedLanguage::Java);
       let package_node = get_package_declaration_node(&ts_file).unwrap();
       let result = get_package_scope_node(&ts_file, package_node);
 
@@ -299,7 +317,8 @@ mod package_declaration_tests {
 
     #[test]
     fn test_complete_identifier_with_whitespace() {
-      let ts_file = TSFile::from_source_code("package   com.example.myapp   ;");
+      let ts_file =
+        TSFile::from_source_code("package   com.example.myapp   ;", SupportedLanguage::Java);
       let package_node = get_package_declaration_node(&ts_file).unwrap();
       let result = get_package_scope_node(&ts_file, package_node);
 
@@ -316,8 +335,10 @@ mod package_declaration_tests {
 
     #[test]
     fn test_comprehensive_package_parsing() {
-      let ts_file =
-        TSFile::from_source_code("package com.company.project.myapp;\n\npublic class MyClass {}");
+      let ts_file = TSFile::from_source_code(
+        "package com.company.project.myapp;\n\npublic class MyClass {}",
+        SupportedLanguage::Java,
+      );
 
       // Get package declaration
       let package_node = get_package_declaration_node(&ts_file);
@@ -347,7 +368,7 @@ mod package_declaration_tests {
 
     #[test]
     fn test_minimal_valid_package() {
-      let ts_file = TSFile::from_source_code("package a.b;");
+      let ts_file = TSFile::from_source_code("package a.b;", SupportedLanguage::Java);
 
       let package_node = get_package_declaration_node(&ts_file);
       assert!(package_node.is_some(), "Should find minimal package declaration");
@@ -391,7 +412,7 @@ mod package_declaration_tests {
                 }
             "#;
 
-      let ts_file = TSFile::from_source_code(java_code);
+      let ts_file = TSFile::from_source_code(java_code, SupportedLanguage::Java);
       let package_node = get_package_declaration_node(&ts_file).unwrap();
 
       // Verify all parsing functions work with complex file
@@ -422,7 +443,7 @@ mod package_declaration_tests {
       ];
 
       for (code, description) in test_cases {
-        let ts_file = TSFile::from_source_code(code);
+        let ts_file = TSFile::from_source_code(code, SupportedLanguage::Java);
         let package_node = get_package_declaration_node(&ts_file);
 
         if package_node.is_none() {


### PR DESCRIPTION
This pull request updates the handling of Java files throughout the codebase by explicitly specifying the language when creating or parsing `TSFile` instances. This change ensures that the correct language is always used for parsing and processing Java source files, improving reliability and future extensibility for other languages. Additionally, documentation and example code have been updated to reflect the new required parameter.

**Java language support enforcement:**

* All usages of `TSFile::from_file`, `TSFile::from_source_code`, and `TSFile::from_base64_source_code` in Java-related services now require a `SupportedLanguage::Java` argument to be passed, ensuring correct parsing context. [[1]](diffhunk://#diff-628f49b6ae08a4a15a9e614b6b2bb6cfbb17ae46c6ec5a87bd810529d58f01e4L25-R26) [[2]](diffhunk://#diff-3596fdd746e83a16c71afc06dcaa6f1d669680353795c4e02c11ad3bde8da4ebL204-R206) [[3]](diffhunk://#diff-466401ccb410b8d6f309fa353843527b245857d564bb23e97c454c976de70406L118-R120) [[4]](diffhunk://#diff-60cf2c5aa268939db183dd3d0d23a6ec575e18a0b959d63f92b9fc76ed67c2c2L172-R174) [[5]](diffhunk://#diff-4a329b163b960473016879fcb7e30f845e14ac9c2fd52c32081c63816d051a61L63-R73) [[6]](diffhunk://#diff-4a329b163b960473016879fcb7e30f845e14ac9c2fd52c32081c63816d051a61L87-R91) [[7]](diffhunk://#diff-890489bdb0bad1b084f1eaba5db21621958de250b1d86463c5fc5199eb3ed94bL83-R84) [[8]](diffhunk://#diff-890489bdb0bad1b084f1eaba5db21621958de250b1d86463c5fc5199eb3ed94bL99-R103) [[9]](diffhunk://#diff-ec53257e68a1fd2acbc8b6cdc019954b6cbb8256995cdb8059d0473925673932L93-R95) [[10]](diffhunk://#diff-ec53257e68a1fd2acbc8b6cdc019954b6cbb8256995cdb8059d0473925673932L232-R235) [[11]](diffhunk://#diff-ec53257e68a1fd2acbc8b6cdc019954b6cbb8256995cdb8059d0473925673932L243-R247) [[12]](diffhunk://#diff-ec53257e68a1fd2acbc8b6cdc019954b6cbb8256995cdb8059d0473925673932L263-R268) [[13]](diffhunk://#diff-4c4cfcbeea3d86166bb665ba6b7b7b3a984a9b61e8aac7a67df04def7448c24bL218-R223)

* Imports for `SupportedLanguage` have been added where necessary in all affected files. [[1]](diffhunk://#diff-628f49b6ae08a4a15a9e614b6b2bb6cfbb17ae46c6ec5a87bd810529d58f01e4R11) [[2]](diffhunk://#diff-3596fdd746e83a16c71afc06dcaa6f1d669680353795c4e02c11ad3bde8da4ebR16) [[3]](diffhunk://#diff-466401ccb410b8d6f309fa353843527b245857d564bb23e97c454c976de70406R15) [[4]](diffhunk://#diff-60cf2c5aa268939db183dd3d0d23a6ec575e18a0b959d63f92b9fc76ed67c2c2R16) [[5]](diffhunk://#diff-4a329b163b960473016879fcb7e30f845e14ac9c2fd52c32081c63816d051a61R21) [[6]](diffhunk://#diff-890489bdb0bad1b084f1eaba5db21621958de250b1d86463c5fc5199eb3ed94bR20) [[7]](diffhunk://#diff-ec53257e68a1fd2acbc8b6cdc019954b6cbb8256995cdb8059d0473925673932R18) [[8]](diffhunk://#diff-4c4cfcbeea3d86166bb665ba6b7b7b3a984a9b61e8aac7a67df04def7448c24bR21)

**Documentation and examples:**

* All doc tests and code examples in `package_declaration_service.rs` have been updated to show usage of `SupportedLanguage::Java` with `TSFile::from_source_code`. [[1]](diffhunk://#diff-1cc6c6641be5c02afe5f914ba6fd69643d2ee06a6b7697938575ae7a23f99721R19-R21) [[2]](diffhunk://#diff-1cc6c6641be5c02afe5f914ba6fd69643d2ee06a6b7697938575ae7a23f99721R47-R49) [[3]](diffhunk://#diff-1cc6c6641be5c02afe5f914ba6fd69643d2ee06a6b7697938575ae7a23f99721R95-R97) [[4]](diffhunk://#diff-1cc6c6641be5c02afe5f914ba6fd69643d2ee06a6b7697938575ae7a23f99721R143-R145)

**Module structure:**

* The `supported_language` module has been added to the `common` module tree, making it available throughout the codebase.