### PR TITLE
feat: add CLI version flag using clap

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ use syntaxpresso_core::common::error_response::ErrorResponse;
 
 #[derive(Parser)]
 #[command(name = "syntaxpresso-core")]
+#[command(version)]
 #[command(
   about = "A standalone Rust-based CLI backend for IDE plugins that provides advanced Java code generation and manipulation capabilities using Tree-Sitter."
 )]


### PR DESCRIPTION
## Summary

This PR merges the "create-version-command" branch into "develop". It introduces a version flag to the syntaxpresso-core CLI, allowing users to easily display the current version of the tool from the command line. This enhancement improves usability and transparency for end users and developers.

## Changes

- Enabled the version flag for the syntaxpresso-core CLI using the clap framework.
- Users can now display the current version of the CLI by invoking the version flag.

## Technical Details

The change leverages clap's built-in `#[command(version)]` attribute in the CLI parser definition, ensuring that version information is automatically managed and displayed when requested.