### PR TITLE
feat: add CLI version flag

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ use syntaxpresso_core::common::error_response::ErrorResponse;
 
 #[derive(Parser)]
 #[command(name = "syntaxpresso-core")]
+#[command(version)]
 #[command(
   about = "A standalone Rust-based CLI backend for IDE plugins that provides advanced Java code generation and manipulation capabilities using Tree-Sitter."
 )]


### PR DESCRIPTION
## Summary

This PR merges the latest changes from the "develop" branch into "main". The primary update is the addition of a version flag to the `syntaxpresso-core` CLI, enhancing usability by allowing users to easily check the current version from the command line.

## Changes

- Enabled a `--version` flag for the `syntaxpresso-core` CLI using the `clap` crate
- Users can now display the current CLI version directly from the command line

## Technical Details

The version flag is implemented via the `#[command(version)]` attribute from `clap`, ensuring the CLI automatically displays version information when invoked with `--version` or `-V`.