### PR TITLE
fix: unify Ctrl+C and Esc handling in form UI

### DIFF
--- a/src/common/ui/form_trait.rs
+++ b/src/common/ui/form_trait.rs
@@ -162,14 +162,6 @@ pub trait FormBehavior {
       }
       return false;
     }
-    // Handle C-c
-    if let KeyCode::Char('c') = key
-      && self.input_mode() == InputMode::Insert
-    {
-      self.set_input_mode(InputMode::Normal);
-      self.escape_handler_mut().reset();
-      return false;
-    }
     // Reset escape handler on any other key
     self.escape_handler_mut().reset();
     // Dispatch to mode-specific handler

--- a/src/common/ui/runner.rs
+++ b/src/common/ui/runner.rs
@@ -43,14 +43,15 @@ fn run_app<B: ratatui::backend::Backend, F: FormBehavior>(
     if let Event::Key(key) = event::read()?
       && key.kind == KeyEventKind::Press
     {
-      if key.code == KeyCode::Char('c') && key.modifiers.contains(KeyModifiers::CONTROL) {
-        if app.handle_input(KeyCode::Char('c')) {
-          return Ok(());
-        }
-        continue;
-      }
+      // Treat Ctrl+C the same as Esc - delegate to form's escape handler
+      let key_code =
+        if key.code == KeyCode::Char('c') && key.modifiers.contains(KeyModifiers::CONTROL) {
+          KeyCode::Esc
+        } else {
+          key.code
+        };
 
-      if app.handle_input(key.code) {
+      if app.handle_input(key_code) {
         return Ok(());
       }
     }


### PR DESCRIPTION
- Remove special-case Ctrl+C handling from FormBehavior trait
- Update runner to treat Ctrl+C as Esc, delegating to escape handler
- Simplifies input logic and ensures consistent escape behavior across modes