### PR TITLE
This pull request improves the user experience

### DIFF
--- a/src/common/ui/form_trait.rs
+++ b/src/common/ui/form_trait.rs
@@ -162,14 +162,6 @@ pub trait FormBehavior {
       }
       return false;
     }
-    // Handle C-c
-    if let KeyCode::Char('c') = key
-      && self.input_mode() == InputMode::Insert
-    {
-      self.set_input_mode(InputMode::Normal);
-      self.escape_handler_mut().reset();
-      return false;
-    }
     // Reset escape handler on any other key
     self.escape_handler_mut().reset();
     // Dispatch to mode-specific handler

--- a/src/common/ui/runner.rs
+++ b/src/common/ui/runner.rs
@@ -43,14 +43,15 @@ fn run_app<B: ratatui::backend::Backend, F: FormBehavior>(
     if let Event::Key(key) = event::read()?
       && key.kind == KeyEventKind::Press
     {
-      if key.code == KeyCode::Char('c') && key.modifiers.contains(KeyModifiers::CONTROL) {
-        if app.handle_input(KeyCode::Char('c')) {
-          return Ok(());
-        }
-        continue;
-      }
+      // Treat Ctrl+C the same as Esc - delegate to form's escape handler
+      let key_code =
+        if key.code == KeyCode::Char('c') && key.modifiers.contains(KeyModifiers::CONTROL) {
+          KeyCode::Esc
+        } else {
+          key.code
+        };
 
-      if app.handle_input(key.code) {
+      if app.handle_input(key_code) {
         return Ok(());
       }
     }


### PR DESCRIPTION
This pull request improves the user experience when editing numeric fields (precision and scale) in the `CreateBasicFieldForm` by introducing more granular focus management and better keyboard navigation. It also standardizes Ctrl+C handling across forms, treating it as an escape action instead of a character input.

**Precision/Scale Field Editing and Focus Management:**

* Added a `precision_scale_sub_focus` field to `CreateBasicFieldForm` to track whether the user is editing the precision or scale subfield, enabling more precise cursor and focus handling. [[1]](diffhunk://#diff-9d220caf534fa986fe7f440f0faf43bd875f6a290c113080f2a11c1c61a17ff7R90) [[2]](diffhunk://#diff-9d220caf534fa986fe7f440f0faf43bd875f6a290c113080f2a11c1c61a17ff7R173)
* Updated input handling so that keyboard navigation (Tab, Left/Right, Home/End, Backspace/Delete) and text editing work intuitively for both precision and scale fields, depending on which subfield is focused.
* Enhanced the UI to visually indicate which subfield (precision or scale) is focused and whether the user is in insert or normal mode, and to display the cursor appropriately.
* Adjusted focus logic so that when the precision/scale field is focused, the correct cursor is positioned for editing either precision or scale.

**Keyboard Shortcut Consistency:**

* Changed Ctrl+C handling: now, pressing Ctrl+C in insert mode is treated the same as pressing Escape, exiting insert mode and resetting the escape handler, rather than being processed as a character input. This is implemented in the UI runner for consistency across all forms. [[1]](diffhunk://#diff-ae05389a2950843252e420d8f49782c577486a35eccf70c99aef7d554136a799L165-L172) [[2]](diffhunk://#diff-e416397cf2d99071748a0e380db3fa7ae5bfbab1d5a03a1ae93fe81aa8515be5R46-R54)